### PR TITLE
fix: copy to clipboard on non secure context (no SSL)

### DIFF
--- a/src/components/Torrent/TorrentRightClickMenu.vue
+++ b/src/components/Torrent/TorrentRightClickMenu.vue
@@ -397,7 +397,22 @@ export default {
       qbit.setAutoTMM(this.hashes, !this.torrent.auto_tmm)
     },
     copyToClipBoard(text) {
-      navigator.clipboard.writeText(text)
+      if (navigator.clipboard && window.isSecureContext) {
+        navigator.clipboard.writeText(text)
+      } else {
+        const textArea = document.createElement('textarea')
+        textArea.value = text
+        textArea.style.position = 'fixed'
+        textArea.style.opacity = '0'
+        document.body.appendChild(textArea)
+        textArea.select()
+        try {
+          document.execCommand('copy')
+        } catch (err) {
+          console.error('Unable to copy to clipboard', err)
+        }
+        document.body.removeChild(textArea)
+      }
     }
   }
 }


### PR DESCRIPTION
Solves #492 

Adds a fallback for the Clipboard API because it's not supported on non SSL environments.
Confirmed to be working on Firefox.

# PR Checklist
- [x] I've started from master
- [x] I've only committed changes related to this PR
- [ ] All Unit tests pass
- [x] I've removed all commented code
- [ ] I've removed all unneeded console.log statements
