### PR TITLE
fix(QbitProvider): manually add indexes to getTorrentFiles response

### DIFF
--- a/src/services/QbitProvider.ts
+++ b/src/services/QbitProvider.ts
@@ -341,6 +341,16 @@ export default class QBitProvider implements IProvider {
         params: { hash, indexes: indexes?.join('|') }
       })
       .then(res => res.data)
+      .then(
+        (files: TorrentFile[]) => (files.some(file => file.index === undefined) ? files.map((file: TorrentFile, index: number) => ({ ...file, index })) : files)
+        /**
+         * We manually add indexes to the response if they are missing to provide compatibility with older versions of qbittorent (< 4.4.0)
+         * https://github.com/qbittorrent/qBittorrent/pull/14795
+         *
+         * We leave newer versions unaltered, as the files could be sent in different orders or be filtered
+         * https://github.com/qbittorrent/qBittorrent/wiki/WebUI-API-(qBittorrent-4.1)#set-file-priority
+         */
+      )
   }
 
   async getAvailableTags(): Promise<string[]> {


### PR DESCRIPTION
# Manually add indexes to getTorrentFiles response

The absence of indexes in `getTorrentFiles`'s response made the request in `setTorrentFilePriority` impossible as it depends on them (id = index in the context).

The error only occurs with older version of Qbittorrent (< 4.4.0). PR that introduces indexes in the response: https://github.com/qbittorrent/qBittorrent/pull/14795

The fix manually add indexes on the returned array. 

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
