### PR TITLE
fix(localization): remove redundant characters from zh-Hans (Simplified Chinese)

### DIFF
--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -1141,7 +1141,7 @@
     },
     "state": {
       "allocating": "分配中",
-      "checkingDL": "校验中 (未完成`)",
+      "checkingDL": "校验中 (未完成)",
       "checkingResumeData": "校验恢复数据",
       "checkingUP": "校验中 (已完成)",
       "downloading": "下载中",


### PR DESCRIPTION
# fix(localization): remove redundant characters from zh-Hans (Simplified Chinese)

The string ```校验中 (未完成`)``` should be `校验中 (未完成)`

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
