### PR TITLE
fix: Refactor pluralization logic in i18n.ts for "ru"

### DIFF
--- a/src/plugins/i18n.ts
+++ b/src/plugins/i18n.ts
@@ -13,6 +13,9 @@ export default createI18n({
       }
       const teen = choice > 10 && choice < 20
       const endsWithOne = choice % 10 === 1
+      if (choicesLength == 2) {
+        return choice === 1 ? 0 : 1
+      }
       if (choicesLength < 4) {
         return !teen && endsWithOne ? 1 : 2
       }


### PR DESCRIPTION
# Refactor pluralization logic in i18n.ts for "ru"

Fixed translation when only 2 options are available

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
