### PR TITLE
perf(Content tab): Allow filtering files by name

### DIFF
--- a/src/components/TorrentDetail/Content/Content.vue
+++ b/src/components/TorrentDetail/Content/Content.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
+import { useSearchQuery } from '@/composables'
 import { useContentStore } from '@/stores'
 import { Torrent, TreeNode } from '@/types/vuetorrent'
 import { storeToRefs } from 'pinia'
-import { computed, nextTick } from 'vue'
+import { computed, nextTick, ref } from 'vue'
 import { useDisplay } from 'vuetify'
 import ContentNode from './ContentNode.vue'
 
@@ -12,11 +13,17 @@ const { height: deviceHeight } = useDisplay()
 const contentStore = useContentStore()
 const { rightClickProperties, openedItems, flatTree, internalSelection } = storeToRefs(contentStore)
 
+const filter = ref<string>('')
+
+const { results: filteredTree } = useSearchQuery(flatTree, filter, item => item.fullName)
+
 const height = computed(() => {
   // 48px for the tabs and page title
   // 64px for the toolbar
   // 12px for the padding (top and bottom)
-  return deviceHeight.value - 48 * 2 - 64 - 12 * 2
+  // 56px for the filter text field
+  // 8px for its top margin
+  return deviceHeight.value - 48 * 2 - 64 - 12 * 2 - 56 - 8
 })
 
 async function onRightClick(e: MouseEvent | Touch, node: TreeNode) {
@@ -39,7 +46,9 @@ async function onRightClick(e: MouseEvent | Touch, node: TreeNode) {
 
 <template>
   <v-card>
-    <v-virtual-scroll id="tree-root" :items="flatTree" :height="height" item-height="68" class="pa-2">
+    <v-text-field v-model="filter" class="mt-2 mx-3" hide-details :placeholder="$t('torrentDetail.content.filter_placeholder')" />
+
+    <v-virtual-scroll id="tree-root" :items="filteredTree" :height="height" item-height="68" class="pa-2">
       <template #default="{ item }">
         <ContentNode
           :opened-items="openedItems"

--- a/src/components/TorrentDetail/Overview.vue
+++ b/src/components/TorrentDetail/Overview.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import ConfirmDeleteDialog from '@/components/Dialogs/ConfirmDeleteDialog.vue'
 import MoveTorrentDialog from '@/components/Dialogs/MoveTorrentDialog.vue'
 import MoveTorrentFileDialog from '@/components/Dialogs/MoveTorrentFileDialog.vue'
 import { FilePriority, PieceState, TorrentState } from '@/constants/qbit'
@@ -124,7 +125,7 @@ watch(cachedFiles, () => {
 })
 
 function handleKeyboardShortcuts(e: KeyboardEvent) {
-  if (dialogStore.hasActiveDialog) return false
+  if (dialogStore.hasActiveDialog || !props.isActive) return false
 
   if (e.key === 'd') {
     e.preventDefault()
@@ -141,6 +142,12 @@ function handleKeyboardShortcuts(e: KeyboardEvent) {
   if (e.key === 'f' && selectedFiles.value.length === 1) {
     e.preventDefault()
     openMoveTorrentFileDialog()
+    return true
+  }
+
+  if (e.key === 'Delete') {
+    e.preventDefault()
+    dialogStore.createDialog(ConfirmDeleteDialog, { hashes: [props.torrent.hash] })
     return true
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1078,6 +1078,7 @@
   },
   "torrentDetail": {
     "content": {
+      "filter_placeholder": "Search in file tree",
       "fileInfo": "{n} file | {n} files",
       "folderInfo": "{n} folder | {n} folders",
       "priority": "Set priority",

--- a/src/pages/TorrentDetail.vue
+++ b/src/pages/TorrentDetail.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import RightClickMenu from '@/components/Core/RightClickMenu'
-import ConfirmDeleteDialog from '@/components/Dialogs/ConfirmDeleteDialog.vue'
 import Content from '@/components/TorrentDetail/Content'
 import Info from '@/components/TorrentDetail/Info/Info.vue'
 import Overview from '@/components/TorrentDetail/Overview.vue'
@@ -40,12 +39,6 @@ const goHome = () => {
 function handleKeyboardShortcut(e: KeyboardEvent) {
   if (dialogStore.hasActiveDialog) {
     return false
-  }
-
-  if (e.key === 'Delete') {
-    dialogStore.createDialog(ConfirmDeleteDialog, { hashes: [hash.value] })
-    e.preventDefault()
-    return true
   }
 
   if (e.key === 'Escape') {


### PR DESCRIPTION
Filter file tree by `fullName` allowing to search through the entire file tree at once.

This was previously impossible with the virtual scroll not rendering all content nodes at once for performance reasons.

`fullName` is used instead of `name` to display a folder's subcontent in the resulting list.