### PR TITLE
Optimize TorrentDetail Overview Piece Renderer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@ctrl/tinycolor": "^4.0.3",
         "@faker-js/faker": "^8.4.1",
+        "@flatten-js/interval-tree": "^1.1.2",
         "@fontsource/roboto": "^5.0.12",
         "@fontsource/roboto-mono": "^5.0.17",
         "@mdi/font": "^7.4.47",
@@ -21,6 +22,7 @@
         "lodash.debounce": "^4.0.8",
         "pinia": "^2.1.6",
         "pinia-plugin-persist": "^1.0.0",
+        "pixi.js": "^8.0.1",
         "uuid": "^9.0.1",
         "vite-plugin-vuetify": "^2.0.2",
         "vue": "^3.4.21",
@@ -571,6 +573,11 @@
         "npm": ">=6.14.13"
       }
     },
+    "node_modules/@flatten-js/interval-tree": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@flatten-js/interval-tree/-/interval-tree-1.1.2.tgz",
+      "integrity": "sha512-OwLoV9E/XM6b7bes2rSFnGNjyRy7vcoIHFTnmBR2WAaZTf0Fe4EX4GdA65vU1KgFAasti7iRSg2dZfYd1Zt00Q=="
+    },
     "node_modules/@fontsource/roboto": {
       "version": "5.0.12",
       "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.0.12.tgz",
@@ -880,6 +887,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@pixi/colord": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
+      "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA=="
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -1275,6 +1287,16 @@
       "resolved": "https://registry.npmmirror.com/@swc/types/-/types-0.1.5.tgz",
       "integrity": "sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==",
       "dev": true
+    },
+    "node_modules/@types/css-font-loading-module": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.12.tgz",
+      "integrity": "sha512-x2tZZYkSxXqWvTDgveSynfjq/T2HyiZHXb00j/+gy19yp70PHCizM48XFdjBCWH7eHBD0R5i/pw9yMBP/BH5uA=="
+    },
+    "node_modules/@types/earcut": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.4.tgz",
+      "integrity": "sha512-qp3m9PPz4gULB9MhjGID7wpo3gJ4bTGXm7ltNDsmOvsPduTeHp8wSW9YckBj3mljeOh4F0m2z/0JKAALRKbmLQ=="
     },
     "node_modules/@types/estree": {
       "version": "1.0.5",
@@ -1936,6 +1958,19 @@
         }
       }
     },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.40",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.40.tgz",
+      "integrity": "sha512-/BBkHLS6/eQjyWhY2H7Dx5DHcVrS2ICj9owvSRdgtQT6KcafLZA86tPze0xAOsd4FbsYKCUBUQyNi87q7gV7kw=="
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/@yr/monotone-cubic-spline": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@yr/monotone-cubic-spline/-/monotone-cubic-spline-1.0.3.tgz",
@@ -2457,6 +2492,11 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/earcut": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -2767,6 +2807,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
     },
     "node_modules/execa": {
       "version": "8.0.1",
@@ -3297,6 +3342,11 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
+    },
+    "node_modules/ismobilejs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
+      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw=="
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -3883,6 +3933,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ=="
+    },
     "node_modules/parse5": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
@@ -4076,6 +4131,22 @@
         "@vue/composition-api": {
           "optional": true
         }
+      }
+    },
+    "node_modules/pixi.js": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.0.1.tgz",
+      "integrity": "sha512-SGtkod644kb/k+hTvSSk9ywpmvgdjiX+gK6NF8He1xyQ0XCRn5ZqN37EPEBsg0ffadjZ40mqtO+2oXyEOLrWzw==",
+      "dependencies": {
+        "@pixi/colord": "^2.9.6",
+        "@types/css-font-loading-module": "^0.0.12",
+        "@types/earcut": "^2.1.4",
+        "@webgpu/types": "^0.1.40",
+        "@xmldom/xmldom": "^0.8.10",
+        "earcut": "^2.2.4",
+        "eventemitter3": "^5.0.1",
+        "ismobilejs": "^1.1.1",
+        "parse-svg-path": "^0.1.2"
       }
     },
     "node_modules/pkg-types": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@ctrl/tinycolor": "^4.0.3",
     "@faker-js/faker": "^8.4.1",
+    "@flatten-js/interval-tree": "^1.1.2",
     "@fontsource/roboto": "^5.0.12",
     "@fontsource/roboto-mono": "^5.0.17",
     "@mdi/font": "^7.4.47",
@@ -28,6 +29,7 @@
     "lodash.debounce": "^4.0.8",
     "pinia": "^2.1.6",
     "pinia-plugin-persist": "^1.0.0",
+    "pixi.js": "^8.0.1",
     "uuid": "^9.0.1",
     "vite-plugin-vuetify": "^2.0.2",
     "vue": "^3.4.21",

--- a/src/components/Settings/VueTorrent/General.vue
+++ b/src/components/Settings/VueTorrent/General.vue
@@ -173,15 +173,6 @@ onBeforeMount(() => {
 
       <v-row>
         <v-col cols="12" md="6">
-          <v-text-field v-model.number="vueTorrentStore.canvasRenderThreshold" hide-details type="number" :label="t('settings.vuetorrent.general.canvasRenderThreshold')" />
-        </v-col>
-        <v-col cols="12" md="6">
-          <v-text-field v-model.number="vueTorrentStore.canvasRefreshThreshold" hide-details type="number" :label="t('settings.vuetorrent.general.canvasRefreshThreshold')" />
-        </v-col>
-      </v-row>
-
-      <v-row>
-        <v-col cols="12" md="6">
           <v-select v-model="vueTorrentStore.language" flat hide-details :items="LOCALES" :label="t('settings.vuetorrent.general.language')" />
         </v-col>
         <v-col cols="12" md="6">

--- a/src/components/TorrentDetail/Overview.vue
+++ b/src/components/TorrentDetail/Overview.vue
@@ -47,8 +47,8 @@ const shouldRefreshPieceState = computed(() => shouldRenderPieceState.value && t
  * Source:
  * https://github.com/qbittorrent/qBittorrent/blob/6229b817300344759139d2fedbd59651065a561d/src/webui/www/private/scripts/prop-general.js#L230
  */
-let pieceApp: Application | null = null
-let pieceLastGraphics: Graphics | null = null
+let piecesApp: Application | null = null
+let piecesAppLastGraphics: Graphics | null = null
 async function renderTorrentPieceStates() {
   if (!canvas.value) return
 
@@ -56,15 +56,15 @@ async function renderTorrentPieceStates() {
 
   // Build lookup for piece ranges of files that aren't DO_NOT_DOWNLOAD
   // allows look up by piece index in O(log(n)) time, previous method lookup time grew quadratically or worse with number of pieces
-  const pieceSelectedRanges = new IntervalTree()
-  for (const file of cachedFiles.value) if (file.priority !== FilePriority.DO_NOT_DOWNLOAD) pieceSelectedRanges.insert([...file.piece_range], file)
+  const piecesSelectedRanges = new IntervalTree()
+  for (const file of cachedFiles.value) if (file.priority !== FilePriority.DO_NOT_DOWNLOAD) piecesSelectedRanges.insert([...file.piece_range], file)
 
   canvas.value.width = 4096
-  if (pieceApp === null) {
-    pieceApp = new Application()
-    await pieceApp.init({ antialias: true, width: canvas.value.width, height: canvas.value.height })
-    ;[...canvas.value.attributes].forEach(attr => (pieceApp !== null && attr.nodeValue !== null ? pieceApp.canvas.setAttribute(attr.nodeName, attr.nodeValue) : null))
-    canvas.value.replaceWith(pieceApp.canvas)
+  if (piecesApp === null) {
+    piecesApp = new Application()
+    await piecesApp.init({ antialias: true, width: canvas.value.width, height: canvas.value.height })
+    ;[...canvas.value.attributes].forEach(attr => (piecesApp !== null && attr.nodeValue !== null ? piecesApp.canvas.setAttribute(attr.nodeName, attr.nodeValue) : null))
+    canvas.value.replaceWith(piecesApp.canvas)
   }
   const graphics = new Graphics()
 
@@ -78,7 +78,7 @@ async function renderTorrentPieceStates() {
 
     if (state === PieceState.DOWNLOADING) newColor = theme.current.value.colors['torrent-downloading']
     else if (state === PieceState.DOWNLOADED) newColor = theme.current.value.colors['torrent-pausedUP']
-    else if (state === PieceState.MISSING && pieceSelectedRanges.intersect_any([i, i])) newColor = theme.current.value.colors['torrent-pausedDL']
+    else if (state === PieceState.MISSING && piecesSelectedRanges.intersect_any([i, i])) newColor = theme.current.value.colors['torrent-pausedDL']
 
     if (newColor === color) {
       ++rectWidth
@@ -100,9 +100,9 @@ async function renderTorrentPieceStates() {
     graphics.fill(color)
   }
 
-  pieceApp.stage.addChild(graphics)
-  if (pieceLastGraphics !== null) pieceLastGraphics.destroy()
-  pieceLastGraphics = graphics
+  piecesApp.stage.addChild(graphics)
+  if (piecesAppLastGraphics !== null) piecesAppLastGraphics.destroy()
+  piecesAppLastGraphics = graphics
 }
 
 async function copyHash() {
@@ -167,8 +167,8 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
-  if (pieceApp !== null) pieceApp.destroy({ removeView: false }, { children: true })
-  if (pieceLastGraphics !== null) pieceLastGraphics.destroy()
+  if (piecesApp !== null) piecesApp.destroy({ removeView: false }, { children: true })
+  if (piecesAppLastGraphics !== null) piecesAppLastGraphics.destroy()
   document.removeEventListener('keydown', handleKeyboardShortcuts)
 })
 </script>

--- a/src/components/TorrentDetail/Overview.vue
+++ b/src/components/TorrentDetail/Overview.vue
@@ -161,10 +161,11 @@ onMounted(async () => {
   if (canvas.value) {
     canvas.value.width = 4096
     if (piecesApp === null) {
-      piecesApp = new Application()
-      await piecesApp.init({ antialias: true, width: canvas.value.width, height: canvas.value.height })
-      ;[...canvas.value.attributes].forEach(attr => (piecesApp !== null && attr.nodeValue !== null ? piecesApp.canvas.setAttribute(attr.nodeName, attr.nodeValue) : null))
-      canvas.value.replaceWith(piecesApp.canvas)
+      const app = new Application()
+      await app.init({ antialias: true, width: canvas.value.width, height: canvas.value.height })
+      ;[...canvas.value.attributes].forEach(attr => (attr.nodeValue !== null ? app.canvas.setAttribute(attr.nodeName, attr.nodeValue) : null))
+      canvas.value.replaceWith(app.canvas)
+      piecesApp = app
     }
   }
 })

--- a/src/components/TorrentDetail/Overview.vue
+++ b/src/components/TorrentDetail/Overview.vue
@@ -48,7 +48,6 @@ const shouldRefreshPieceState = computed(() => shouldRenderPieceState.value && t
  * https://github.com/qbittorrent/qBittorrent/blob/6229b817300344759139d2fedbd59651065a561d/src/webui/www/private/scripts/prop-general.js#L230
  */
 let pieceApp: Application | null = null
-let pieceSelectedRanges: IntervalTree | null = null
 let pieceLastGraphics: Graphics | null = null
 async function renderTorrentPieceStates() {
   if (!canvas.value) return
@@ -57,10 +56,8 @@ async function renderTorrentPieceStates() {
 
   // Build lookup for piece ranges of files that aren't DO_NOT_DOWNLOAD
   // allows look up by piece index in O(log(n)) time, previous method lookup time grew quadratically or worse with number of pieces
-  if (pieceSelectedRanges === null) {
-    pieceSelectedRanges = new IntervalTree()
-    for (const file of cachedFiles.value) if (file.priority !== FilePriority.DO_NOT_DOWNLOAD) pieceSelectedRanges.insert([...file.piece_range], file)
-  }
+  const pieceSelectedRanges = new IntervalTree()
+  for (const file of cachedFiles.value) if (file.priority !== FilePriority.DO_NOT_DOWNLOAD) pieceSelectedRanges.insert([...file.piece_range], file)
 
   canvas.value.width = 4096
   if (pieceApp === null) {

--- a/src/components/TorrentDetail/Overview.vue
+++ b/src/components/TorrentDetail/Overview.vue
@@ -163,7 +163,7 @@ onMounted(async () => {
     if (piecesApp === null) {
       const app = new Application()
       await app.init({ antialias: true, width: canvas.value.width, height: canvas.value.height })
-      ;[...canvas.value.attributes].forEach(attr => (attr.nodeValue !== null ? app.canvas.setAttribute(attr.nodeName, attr.nodeValue) : null))
+      for (const attr of [...canvas.value.attributes]) app.canvas.setAttribute(attr.nodeName, attr.nodeValue ?? '')
       canvas.value.replaceWith(app.canvas)
       piecesApp = app
     }

--- a/src/components/TorrentDetail/PieceCanvas.vue
+++ b/src/components/TorrentDetail/PieceCanvas.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import { FilePriority, PieceState } from '@/constants/qbit'
+import { useContentStore, useMaindataStore } from '@/stores'
+import { Torrent } from '@/types/vuetorrent'
+import IntervalTree from '@flatten-js/interval-tree'
+import { storeToRefs } from 'pinia'
+import { Application, Graphics } from 'pixi.js'
+import { onMounted } from 'vue'
+import { onUnmounted, ref, watch } from 'vue'
+import { useTheme } from 'vuetify'
+
+const props = defineProps<{ torrent: Torrent; isActive: boolean }>()
+
+const theme = useTheme()
+const { cachedFiles } = storeToRefs(useContentStore())
+const maindataStore = useMaindataStore()
+
+const canvas = ref<HTMLCanvasElement>()
+
+const app = ref<Application>()
+const lastGraphics = ref<Graphics>()
+
+async function renderCanvas() {
+  if (!canvas.value || !app.value) return
+
+  const pieces = await maindataStore.fetchPieceState(props.torrent.hash)
+
+  const selectedRanges = new IntervalTree()
+  cachedFiles.value.filter(file => file.priority !== FilePriority.DO_NOT_DOWNLOAD).forEach(file => selectedRanges.insert(file.piece_range, file.name))
+
+  const graphics = new Graphics()
+
+  // Group contiguous colors together and draw as a single rectangle
+  let color = ''
+  let rectWidth = 1
+
+  for (let i = 0; i < pieces.length; ++i) {
+    const state = pieces[i]
+    let newColor = ''
+
+    if (state === PieceState.DOWNLOADING) newColor = theme.current.value.colors['torrent-downloading']
+    else if (state === PieceState.DOWNLOADED) newColor = theme.current.value.colors['torrent-pausedUP']
+    else if (state === PieceState.MISSING && selectedRanges.intersect_any([i, i])) newColor = theme.current.value.colors['torrent-pausedDL']
+
+    if (newColor === color) {
+      ++rectWidth
+      continue
+    }
+
+    if (color !== '') {
+      graphics.rect(((i - rectWidth) / pieces.length) * canvas.value.width, 0, (rectWidth / pieces.length) * canvas.value.width, canvas.value.height)
+      graphics.fill(color)
+    }
+
+    rectWidth = 1
+    color = newColor
+  }
+
+  // Fill a rect at the end of the canvas if one is needed
+  if (color !== '') {
+    graphics.rect(((pieces.length - rectWidth) / pieces.length) * canvas.value.width, 0, (rectWidth / pieces.length) * canvas.value.width, canvas.value.height)
+    graphics.fill(color)
+  }
+
+  app.value.stage.addChild(graphics)
+  if (lastGraphics.value) lastGraphics.value.destroy()
+  lastGraphics.value = graphics
+}
+
+watch(cachedFiles, () => {
+  if (props.isActive) {
+    renderCanvas()
+  }
+})
+
+onMounted(async () => {
+  if (!canvas.value) return
+
+  app.value = new Application()
+  await app.value.init({ antialias: true, width: canvas.value.width, height: canvas.value.height, canvas: canvas.value })
+  if (cachedFiles.value) {
+    renderCanvas()
+  }
+})
+
+onUnmounted(() => {
+  if (app.value) app.value.destroy(false, { children: true })
+})
+</script>
+
+<template>
+  <canvas ref="canvas" height="20" />
+</template>
+
+<style scoped>
+canvas {
+  height: 100%;
+  width: 100%;
+}
+</style>

--- a/src/components/TorrentDetail/PieceCanvas.vue
+++ b/src/components/TorrentDetail/PieceCanvas.vue
@@ -89,7 +89,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <canvas ref="canvas" height="20" />
+  <canvas ref="canvas" width="4096" height="20" />
 </template>
 
 <style scoped>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -910,8 +910,6 @@
     "title": "Settings",
     "vuetorrent": {
       "general": {
-        "canvasRefreshThreshold": "Piece count to disable canvas auto-refresh",
-        "canvasRenderThreshold": "Piece count to disable canvas rendering",
         "check_new": "Check for new version",
         "currentVersion": "Current Version",
         "customTitle": "Custom title",
@@ -1080,8 +1078,6 @@
       "text_values": "Text values"
     },
     "overview": {
-      "canvasRefreshDisabled": "Canvas auto-refresh is disabled",
-      "canvasRenderDisabled": "Canvas rendering is disabled",
       "copy_hash": "Copy Hash",
       "dlSpeedAverage": "Download Speed Average",
       "downloaded": "Downloaded",

--- a/src/stores/vuetorrent.ts
+++ b/src/stores/vuetorrent.ts
@@ -33,8 +33,6 @@ export const useVueTorrentStore = defineStore(
     const useBinarySize = ref(false)
     const refreshInterval = ref(2000)
     const fileContentInterval = ref(5000)
-    const canvasRenderThreshold = ref(3000)
-    const canvasRefreshThreshold = ref(5000)
     const useIdForRssLinks = ref(false)
 
     const _busyProperties = ref<PropertyData>(JSON.parse(JSON.stringify(propsData)))
@@ -215,8 +213,6 @@ export const useVueTorrentStore = defineStore(
     }
 
     return {
-      canvasRenderThreshold,
-      canvasRefreshThreshold,
       vuetorrentTheme,
       dateFormat,
       deleteWithFiles,
@@ -290,8 +286,6 @@ export const useVueTorrentStore = defineStore(
         useBinarySize.value = false
         refreshInterval.value = 2000
         fileContentInterval.value = 5000
-        canvasRenderThreshold.value = 3000
-        canvasRefreshThreshold.value = 5000
         useIdForRssLinks.value = false
 
         _busyProperties.value = JSON.parse(JSON.stringify(propsData))


### PR DESCRIPTION
# Optimize TorrentDetail Overview Piece Renderer [feat/fix/perf]

* Implement WebGL/WebGPU rendering to better handle larger number of pieces (using pixi.js library)
* Re-work portion of rendering logic with very poor logarithmic efficiency (using @flatten-js/interval-tree library)

Working smoothly with 717590 pieces:
![image](https://github.com/VueTorrent/VueTorrent/assets/658757/15f9e71e-4bc3-4ac1-8a73-ab289d827797)

I probably need help reviewing that I've implemented this the right way, used the right conventions.  I've not worked with Vue or Typescript before so particularly type specifications and doing garbage collection on `onUnmounted` should be looked at to make sure I did those things correctly.

## PR Checklist

- [X] I've started from master
- [X] I've only committed changes related to this PR
- [X] All tests pass
- [X] I've removed all commented code
