### PR TITLE
chore: Update VSCode plugin recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["Vue.volar", "Vue.vscode-typescript-vue-plugin"]
+  "recommendations": ["Vue.volar"]
 }


### PR DESCRIPTION
Deleting Volar typescript plugin recommendation after deprecation

> This extension is deprecated. Use the "Vue - Official" (Vue.volar) extension instead.