### PR TITLE
feat(Peers): Show client, peer_id, and i18n strings

### DIFF
--- a/src/components/TorrentDetail/Peers.vue
+++ b/src/components/TorrentDetail/Peers.vue
@@ -88,6 +88,8 @@ watch(() => props.isActive, setupTimer)
 
               <div>Progress: {{ formatPercent(peer.progress) }}</div>
 
+              <div v-show="peer.client || peer.peer_id_client">Client: {{ peer.client }} ({{ peer.peer_id_client }})</div>
+
               <div>
                 <v-icon icon="mdi-arrow-down" color="download" />
                 {{ formatSpeed(peer.dl_speed, vuetorrentStore.useBitSpeed) }}

--- a/src/components/TorrentDetail/Peers.vue
+++ b/src/components/TorrentDetail/Peers.vue
@@ -82,13 +82,13 @@ watch(() => props.isActive, setupTimer)
             </v-list-item-title>
 
             <v-list-item-subtitle class="d-block">
-              <div>
-                Flags: <span class="cursor-help" :title="peer.flags_desc">{{ peer.flags }}</span>
+              <div v-show="peer.flags">
+                {{ $t('torrentDetail.peers.table.flags') }}: <span class="cursor-help" :title="peer.flags_desc">{{ peer.flags }}</span>
               </div>
 
-              <div>Progress: {{ formatPercent(peer.progress) }}</div>
+              <div>{{ $t('torrentDetail.peers.table.progress') }}: {{ formatPercent(peer.progress) }}</div>
 
-              <div v-show="peer.client || peer.peer_id_client">Client: {{ peer.client }} ({{ peer.peer_id_client }})</div>
+              <div v-show="peer.client || peer.peer_id_client">{{ $t('torrentDetail.peers.table.client') }}: {{ peer.client }} ({{ peer.peer_id_client }})</div>
 
               <div>
                 <v-icon icon="mdi-arrow-down" color="download" />
@@ -99,12 +99,14 @@ watch(() => props.isActive, setupTimer)
               </div>
 
               <div>
+                {{ $t('torrentDetail.peers.table.downloaded') }}
                 {{ formatData(peer.downloaded, vuetorrentStore.useBinarySize) }}
                 |
+                {{ $t('torrentDetail.peers.table.uploaded') }}
                 {{ formatData(peer.uploaded, vuetorrentStore.useBinarySize) }}
               </div>
 
-              <div>Relevance: {{ formatPercent(peer.relevance) }}</div>
+              <div>{{ $t('torrentDetail.peers.table.relevance') }}: {{ formatPercent(peer.relevance) }}</div>
             </v-list-item-subtitle>
           </div>
 


### PR DESCRIPTION
# feat(Peers): Show client, peer_id, and i18n strings

Improve peers info display, including:

- Show client type and peer_id.
- Show i18n strings correctly.

See screenshot for details.

![vt-diff](https://github.com/VueTorrent/VueTorrent/assets/25260404/fda29f57-356c-4ec0-91a2-f11f7e1b8153)

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code 