### PR TITLE
fix(ServiceWorker): sw.js url

### DIFF
--- a/public/registerSW.js
+++ b/public/registerSW.js
@@ -1,1 +1,1 @@
-"serviceWorker"in navigator&&window.addEventListener("load",(async()=>{await navigator.serviceWorker.register("/sw.js")}))
+"serviceWorker"in navigator&&window.addEventListener("load",(async()=>{await navigator.serviceWorker.register("sw.js")}))


### PR DESCRIPTION
make sw.js work for url like 'https://mydomain.com/vuetorrent/', otherwise the console will output error.
## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
