### PR TITLE
feat(TorrentDetail): add bulk renaming

### DIFF
--- a/src/components/Core/HistoryField.vue
+++ b/src/components/Core/HistoryField.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import { HistoryKey } from '@/constants/vuetorrent'
 import { useHistoryStore } from '@/stores'
-import { computed, ref, useSlots } from 'vue'
+import { computed, ref } from 'vue'
 
 const props = defineProps<{
   historyKey: HistoryKey
 }>()
-
-const slots = useSlots()
 
 const _value = defineModel<string | undefined>({ required: true })
 
@@ -29,7 +27,7 @@ defineExpose({
 
 <template>
   <v-combobox v-model="_value" ref="field" :items="historyValue">
-    <template v-slot:prepend v-if="slots.prepend"><slot name="prepend" /></template>
+    <template v-slot:prepend v-if="$slots.prepend"><slot name="prepend" /></template>
   </v-combobox>
 </template>
 

--- a/src/components/Core/HistoryField.vue
+++ b/src/components/Core/HistoryField.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { HistoryKey } from '@/constants/vuetorrent'
 import { useHistoryStore } from '@/stores'
-import { computed, ref } from 'vue'
+import { computed, ref, useSlots } from 'vue'
 
 const props = defineProps<{
   historyKey: HistoryKey
 }>()
+
+const slots = useSlots()
 
 const _value = defineModel<string | undefined>({ required: true })
 
@@ -27,7 +29,7 @@ defineExpose({
 
 <template>
   <v-combobox v-model="_value" ref="field" :items="historyValue">
-    <template v-slot:prepend><slot name="prepend" /></template>
+    <template v-slot:prepend v-if="slots.prepend"><slot name="prepend" /></template>
   </v-combobox>
 </template>
 

--- a/src/components/Dialogs/BulkRenameFilesDialog.vue
+++ b/src/components/Dialogs/BulkRenameFilesDialog.vue
@@ -157,7 +157,11 @@ const fileCheckChange = (item: ItemRow) => {
   dryRunRename([item])
 }
 
-const dryRunRename = (partialItems?: ItemRow[]) => {
+const dryRunRename = async (partialItems?: ItemRow[]) => {
+  await form.value?.validate()
+  if (!isFormValid.value) {
+    return
+  }
   let regexp: RegExp
   try {
     regexp = new RegExp(regexpInput.value, regexpFlagsInput.value.join(''))
@@ -166,7 +170,7 @@ const dryRunRename = (partialItems?: ItemRow[]) => {
   }
   ;(partialItems ? partialItems : items).forEach(item => {
     if (item.type === 'file') {
-      if (isFormValid.value && item.selected && regexp.test(item.name)) {
+      if (item.selected && regexp.test(item.name)) {
         item.targetName = item.name.replace(regexp, targetInput.value)
         item.targetFullName = (item.parentItem!.fullName === '' ? '' : item.parentItem!.fullName + '/') + item.targetName
       } else {
@@ -241,7 +245,7 @@ onMounted(() => {
       <v-card-text class="d-flex flex-column">
         <v-form v-model="isFormValid" ref="form">
           <v-row no-gutters align="center" justify="center">
-            <v-col :cols="$vuetify.display.mobile ? 12 : undefined">
+            <v-col :cols="$vuetify.display.mobile ? 9 : undefined">
               <HistoryField
                 :historyKey="HistoryKey.BULK_RENAME_REGEXP"
                 ref="regexpEl"
@@ -250,17 +254,18 @@ onMounted(() => {
                 v-model="regexpInput"
                 :rules="rules"
                 :label="$t('dialogs.bulkRenameFiles.regexp')">
-                <template v-slot:append>
-                  <v-select
-                    v-model="regexpFlagsInput"
-                    :items="['d', 'g', 'i', 'm', 's', 'u', 'v', 'y']"
-                    :placeholder="t('dialogs.bulkRenameFiles.select_regex_flags')"
-                    label="Flags"
-                    density="compact"
-                    multiple
-                    hide-details></v-select>
-                </template>
               </HistoryField>
+            </v-col>
+            <v-col :cols="$vuetify.display.mobile ? 3 : 'auto'">
+              <v-select
+                class="ml-2"
+                v-model="regexpFlagsInput"
+                :items="['d', 'g', 'i', 'm', 's', 'u', 'v', 'y']"
+                :placeholder="t('dialogs.bulkRenameFiles.select_regex_flags')"
+                label="Flags"
+                density="compact"
+                multiple
+                hide-details></v-select>
             </v-col>
             <v-col cols="auto">
               <v-icon class="mx-2" :icon="`mdi-arrow-${$vuetify.display.mobile ? 'down' : 'right'}`" />
@@ -273,7 +278,8 @@ onMounted(() => {
                 density="compact"
                 v-model="targetInput"
                 :rules="rules"
-                :label="$t('dialogs.bulkRenameFiles.target')" />
+                :label="$t('dialogs.bulkRenameFiles.target')">
+              </HistoryField>
             </v-col>
             <v-col cols="auto">
               <v-badge :class="$vuetify.display.mobile ? 'mt-2' : 'ml-5'" color="success" location="top left" :content="candidateItems.length">
@@ -330,9 +336,6 @@ onMounted(() => {
 </template>
 
 <style lang="scss" scoped>
-.v-select {
-  min-width: 100px;
-}
 .v-card-text {
   height: calc(100vh - 112px);
 }

--- a/src/components/Dialogs/BulkRenameFilesDialog.vue
+++ b/src/components/Dialogs/BulkRenameFilesDialog.vue
@@ -1,0 +1,317 @@
+<script setup lang="ts">
+import { useDialog } from '@/composables'
+import { getFileIcon } from '@/constants/vuetorrent'
+import { useContentStore, useVueTorrentStore } from '@/stores'
+import { TreeFolder, TreeNode } from '@/types/vuetorrent'
+import { storeToRefs } from 'pinia'
+import { reactive, ref, onMounted, watch, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { toast } from 'vue3-toastify'
+import { VForm } from 'vuetify/components'
+
+const props = defineProps<{
+  guid: string
+  node: TreeFolder
+  hash: string
+}>()
+
+const { isOpened } = useDialog(props.guid)
+const { t } = useI18n()
+const vueTorrentStore = storeToRefs(useVueTorrentStore())
+const contentStore = useContentStore()
+
+const form = ref<VForm>()
+const isFormValid = ref(false)
+const hasDuplicated = ref(false)
+const regexpInput = vueTorrentStore.bulkRenameRegexp
+const regexpFlagsInput = vueTorrentStore.bulkRenameRegexpFlags
+const targetInput = vueTorrentStore.bulkRenameTarget
+const running = ref(false)
+
+const rules = [(v: string) => !!v]
+
+const headers = [
+  { title: '', sortable: false, key: 'selected', width: '50px' },
+  { title: t('dialogs.bulkRenameFiles.col_origin_name'), sortable: false, key: 'name' },
+  { title: t('dialogs.bulkRenameFiles.col_result_name'), sortable: false, key: 'targetName' }
+]
+
+type ItemRow<T extends TreeNode = TreeNode> = Pick<T, 'name' | 'fullName'> & {
+  indent: number
+  selected: boolean
+  show: boolean
+  folded?: boolean // folder only
+  indeterminate?: boolean // folder only
+  parentItem?: ItemRow
+  duplicated?: boolean
+  notChanged?: boolean
+  targetName?: string
+  targetFullName?: string
+  node: T
+} & (T extends TreeFolder ? { type: 'folder' } : { type: 'file' })
+const items = reactive<ItemRow[]>([])
+const candidateItems = computed(() => items.filter(item => item.type === 'file' && item.selected && item.targetName && item.name !== item.targetName))
+
+/** parse TreeNode to plain list */
+const parseNode = (node: TreeNode, parentItem: ItemRow | undefined = undefined, indent: number = 0) => {
+  const item: ItemRow = {
+    indent,
+    name: node.name,
+    fullName: node.fullName,
+    parentItem,
+    show: true,
+    folded: false,
+    selected: false,
+    type: node.type,
+    /** keep the corresponding node, for expand/collapse folder */
+    node
+  }
+  items.push(item)
+  if (node.type === 'folder') {
+    for (const child of node.children) {
+      parseNode(child, item, indent + 1)
+    }
+  }
+}
+
+const toggleFolderFolded = (item: ItemRow, folded: boolean) => {
+  item.folded = folded
+  ;(item as ItemRow<TreeFolder>).node.children.forEach(node => {
+    const correspondence = items.find(item => item.node === node)!
+    correspondence.show = !folded
+    if (correspondence.type === 'folder') {
+      if (folded) {
+        toggleFolderFolded(correspondence, folded)
+      }
+    }
+  })
+}
+
+/**
+ * @return
+ *  * -1: not selected
+ *  * 0: indeterminate(folder only)
+ *  * 1: selected
+ */
+const detectIndeterminate = (node: TreeNode): -1 | 0 | 1 => {
+  const correspondence = items.find(item => item.node === node)!
+  if (node.type === 'folder') {
+    let selectedLength = 0
+    let indeterminateLength = 0
+    node.children.forEach(item => {
+      switch (detectIndeterminate(item)) {
+        case 1:
+          selectedLength++
+          break
+        case 0:
+          indeterminateLength++
+          break
+      }
+    })
+    if (selectedLength === 0 && indeterminateLength === 0) {
+      correspondence.selected = false
+      correspondence.indeterminate = false
+      return -1
+    } else if (selectedLength === node.children.length) {
+      correspondence.selected = true
+      correspondence.indeterminate = false
+      return 1
+    } else {
+      correspondence.indeterminate = true
+      return 0
+    }
+  } else {
+    correspondence.indeterminate = false
+    return correspondence.selected ? 1 : -1
+  }
+}
+
+const folderCheckChange = (item: ItemRow) => {
+  ;(item as ItemRow<TreeFolder>).node.children.forEach(child => {
+    const foundRow = items.find(row => row.node === child)
+    if (foundRow) {
+      foundRow.selected = item.selected
+      if (foundRow.selected) {
+        // unfold all children when selected
+        foundRow.show = true
+        foundRow.folded = false
+      }
+      if (foundRow.type === 'folder') {
+        folderCheckChange(foundRow as ItemRow<TreeFolder>)
+      }
+    }
+  })
+  detectIndeterminate(props.node)
+  // unfold when selected
+  if (item.selected) {
+    item.show = true
+    item.folded = false
+  }
+  dryRunRename()
+}
+
+const fileCheckChange = (item: ItemRow) => {
+  detectIndeterminate(props.node)
+  dryRunRename([item])
+}
+
+const dryRunRename = (partialItems?: ItemRow[]) => {
+  const regexp = new RegExp(regexpInput.value, regexpFlagsInput.value.join(''))
+  ;(partialItems ? partialItems : items).forEach(item => {
+    if (item.type === 'file') {
+      if (isFormValid.value && item.selected && regexp.test(item.name)) {
+        item.targetName = item.name.replace(regexp, targetInput.value)
+        item.targetFullName = (item.parentItem!.fullName === '' ? '' : item.parentItem!.fullName + '/') + item.targetName
+      } else {
+        item.targetName = undefined
+        item.targetFullName = undefined
+      }
+      item.notChanged = item.name === item.targetName
+    }
+  })
+  hasDuplicated.value = false
+  const allTarget = new Map()
+  items
+    .filter(item => !!item.targetFullName)
+    .forEach(item => {
+      allTarget.set(item.targetFullName, (allTarget.get(item.targetFullName) || 0) + 1)
+    })
+  items.forEach(item => {
+    item.duplicated = allTarget.get(item.targetFullName) > 1
+    if (item.duplicated) {
+      hasDuplicated.value = true
+    }
+  })
+}
+
+const run = async () => {
+  if (!candidateItems.value.length) {
+    return toast.warn(t('dialogs.bulkRenameFiles.nothing_no_do'))
+  }
+  const reqList = []
+  for (const item of candidateItems.value) {
+    reqList.push(contentStore.renameTorrentFile(props.hash, item.fullName, item.targetFullName!))
+  }
+  running.value = true
+  Promise.all(reqList)
+    .then(() => {
+      toast.success(t('dialogs.bulkRenameFiles.success'))
+    })
+    .catch(e => {
+      toast.error(e.toString())
+    })
+    .finally(() => {
+      running.value = false
+      contentStore.updateFileTree()
+      // close dialog, because haven't a good way to refresh torrent files after rename
+      // because bulkRenameFilesDialog can be create with subfolder
+      close()
+    })
+}
+
+const close = () => {
+  isOpened.value = false
+}
+
+watch([regexpInput, regexpFlagsInput, targetInput], () => {
+  dryRunRename()
+})
+
+onMounted(() => {
+  parseNode(props.node)
+})
+</script>
+
+<template>
+  <v-dialog v-model="isOpened" persistent>
+    <v-card density="compact">
+      <v-card-title>
+        {{ $t('dialogs.bulkRenameFiles.title') }}
+        <v-btn style="float: right" icon="mdi-close" variant="plain" density="compact" @click="close()"></v-btn>
+      </v-card-title>
+      <v-card-text>
+        <v-form v-model="isFormValid" ref="form">
+          <v-text-field hide-details density="compact" v-model="regexpInput" :rules="rules" :label="$t('dialogs.bulkRenameFiles.regexp')">
+            <template v-slot:append>
+              <v-select
+                class="flags-select"
+                v-model="regexpFlagsInput"
+                :items="['d', 'g', 'i', 'm', 's', 'u', 'v', 'y']"
+                hint="Select Regular Expression Flags"
+                label="Flags"
+                density="compact"
+                multiple
+                hide-details></v-select>
+            </template>
+          </v-text-field>
+          ->
+          <v-text-field hide-details density="compact" v-model="targetInput" :rules="rules" :label="$t('dialogs.bulkRenameFiles.target')" />
+          <v-badge color="success" :content="candidateItems.length">
+            <v-btn :loading="running" :disabled="!isFormValid || hasDuplicated" color="primary" @click="run()">{{ $t('dialogs.bulkRenameFiles.run') }}</v-btn>
+          </v-badge>
+        </v-form>
+        <v-data-table-virtual :headers="headers" :items="items" density="compact" height="calc(100vh - 200px)" fixed-header>
+          <template v-slot:item="{ index, item }">
+            <v-data-table-row v-show="item.show" :index="index" :item="item as any">
+              <template v-slot:item.selected>
+                <v-checkbox-btn v-if="item.type === 'file'" v-model="item.selected" :color="item.targetName && 'indigo'" @change="fileCheckChange(item)" />
+                <v-checkbox-btn v-else v-model="item.selected" :indeterminate="item.indeterminate" @change="folderCheckChange(item)" />
+              </template>
+              <template v-slot:item.name>
+                <span class="fold-toggle" :class="{ clickable: item.type === 'folder' }" @click="item.type === 'folder' && toggleFolderFolded(item, !item.folded)">
+                  <v-tooltip v-if="item.type === 'folder'" location="top" activator="parent">
+                    {{ t(`dialogs.bulkRenameFiles.${item.folded ? 'unfold' : 'fold'}`) }}
+                  </v-tooltip>
+                  {{ '&emsp;'.repeat(item.indent) }}
+                  <v-icon v-if="item.type === 'folder'">{{ item.folded ? 'mdi-chevron-down' : 'mdi-chevron-up' }}</v-icon>
+                  <v-icon v-if="node.fullName === ''" icon="mdi-file-tree" />
+                  <v-icon v-else-if="item.type === 'file'" :icon="getFileIcon(item.name)" />
+                  <v-icon v-else-if="!item.folded" icon="mdi-folder-open" color="#ffe476" />
+                  <v-icon v-else icon="mdi-folder" color="#ffe476" />
+                  {{ item.name }}
+                </span>
+              </template>
+              <template v-slot:item.targetName>
+                <span v-if="item.type === 'file'" class="target-name" :class="{ duplicated: item.duplicated, 'not-changed': item.notChanged }"
+                  >{{ item.targetName }}
+                  <v-tooltip v-if="item.duplicated || item.notChanged" activator="parent">
+                    {{ t(`dialogs.bulkRenameFiles.${item.duplicated ? 'duplicated' : 'not_changed'}`) }}
+                  </v-tooltip>
+                </span>
+                <span v-else>
+                  <v-icon icon="mdi-cancel" color="grey-lighten-1" />
+                  <v-tooltip activator="parent">
+                    {{ t('dialogs.bulkRenameFiles.notForFolder') }}
+                  </v-tooltip>
+                </span>
+              </template>
+            </v-data-table-row>
+          </template>
+          <template v-slot:bottom></template>
+        </v-data-table-virtual>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+
+<style lang="scss" scoped>
+form {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  .flags-select {
+    min-width: 100px;
+  }
+}
+.target-name {
+  &.duplicated {
+    color: red;
+  }
+  &.not-changed {
+    color: rgb(255, 149, 149);
+  }
+}
+.fold-toggle.clickable {
+  cursor: pointer;
+}
+</style>

--- a/src/components/Dialogs/BulkRenameFilesDialog.vue
+++ b/src/components/Dialogs/BulkRenameFilesDialog.vue
@@ -231,18 +231,17 @@ onMounted(() => {
 <template>
   <v-dialog v-model="isOpened" persistent>
     <v-card density="compact">
-        <v-toolbar color="transparent">
-          <v-toolbar-title>{{ $t('dialogs.bulkRenameFiles.title') }}</v-toolbar-title>
-          <v-btn icon="mdi-close" @click="close()" />
-        </v-toolbar>
-      <v-card-text>
+      <v-toolbar color="transparent">
+        <v-toolbar-title>{{ $t('dialogs.bulkRenameFiles.title') }}</v-toolbar-title>
+        <v-btn icon="mdi-close" @click="close()" />
+      </v-toolbar>
+      <v-card-text class="d-flex flex-column">
         <v-form v-model="isFormValid" ref="form">
           <v-row no-gutters align="center" justify="center">
             <v-col :cols="$vuetify.display.mobile ? 12 : undefined">
               <v-text-field hide-details density="compact" v-model="regexpInput" :rules="rules" :label="$t('dialogs.bulkRenameFiles.regexp')">
                 <template v-slot:append>
                   <v-select
-                    style="min-width: 100px"
                     v-model="regexpFlagsInput"
                     :items="['d', 'g', 'i', 'm', 's', 'u', 'v', 'y']"
                     :placeholder="t('dialogs.bulkRenameFiles.select_regex_flags')"
@@ -266,7 +265,7 @@ onMounted(() => {
             </v-col>
           </v-row>
         </v-form>
-        <v-data-table-virtual :headers="headers" :items="items" density="compact" height="calc(100vh - 200px)" fixed-header>
+        <v-data-table-virtual :headers="headers" :items="items" density="compact" fixed-header>
           <template v-slot:item="{ index, item }">
             <v-data-table-row v-show="item.show" :index="index" :item="item as any">
               <template v-slot:item.selected>
@@ -310,6 +309,15 @@ onMounted(() => {
 </template>
 
 <style lang="scss" scoped>
+.v-select {
+  min-width: 100px;
+}
+.v-card-text {
+  height: calc(100vh - 112px)
+}
+.v-table {
+  overflow: auto;
+}
 .target-name {
   &.duplicated {
     color: red;

--- a/src/constants/vuetorrent/HistoryKey.ts
+++ b/src/constants/vuetorrent/HistoryKey.ts
@@ -1,5 +1,7 @@
 export enum HistoryKey {
   COOKIE = 'cookie',
   SEARCH_ENGINE_QUERY = 'searchEngineQuery',
-  TORRENT_PATH = 'torrentPath'
+  TORRENT_PATH = 'torrentPath',
+  BULK_RENAME_REGEXP = 'bulkRenameRegexp',
+  BULK_RENAME_TARGET = 'bulkRenameTarget'
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -364,13 +364,13 @@
       "col_result_name": "Result",
       "run": "Run",
       "success": "Rename Successful",
-      "nothing_no_do": "No tasks to do",
       "duplicated": "Duplicate Filename",
       "not_changed": "Filename Not Changed",
       "fold": "Collapse",
       "unfold": "Expand",
       "notForFolder": "Folder Renaming Not Supported",
-      "select_regex_flags": "Select Regular Expression Flags"
+      "select_regex_flags": "Select Regular Expression Flags",
+      "nothing_to_do": "No tasks to do"
     },
     "rss": {
       "feed": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -356,6 +356,21 @@
       "sameName": "New name must be different from old name",
       "title": "Rename Torrent"
     },
+    "bulkRenameFiles": {
+      "title": "Bulk Rename",
+      "regexp": "Regular Expression",
+      "target": "Replacement Input",
+      "col_origin_name": "Original",
+      "col_result_name": "Result",
+      "run": "Run",
+      "success": "Rename Successful",
+      "nothing_no_do": "No tasks to do",
+      "duplicated": "Duplicate Filename",
+      "not_changed": "Filename Not Changed",
+      "fold": "Collapse",
+      "unfold": "Expand",
+      "notForFolder": "Folder Renaming Not Supported"
+    },
     "rss": {
       "feed": {
         "name": "Name",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -369,7 +369,8 @@
       "not_changed": "Filename Not Changed",
       "fold": "Collapse",
       "unfold": "Expand",
-      "notForFolder": "Folder Renaming Not Supported"
+      "notForFolder": "Folder Renaming Not Supported",
+      "select_regex_flags": "Select Regular Expression Flags"
     },
     "rss": {
       "feed": {

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -352,6 +352,21 @@
       "sameName": "新名称必须与旧名称不同",
       "title": "重命名种子"
     },
+    "bulkRenameFiles": {
+      "title": "批量重命名",
+      "regexp": "正则表达式",
+      "target": "替换输入",
+      "col_origin_name": "原始",
+      "col_result_name": "结果",
+      "run": "执行",
+      "success": "重命名成功",
+      "nothing_no_do": "无任务可做",
+      "duplicated": "文件名重复",
+      "not_changed": "文件名未修改",
+      "fold": "收起",
+      "unfold": "展开",
+      "notForFolder": "不支持修改文件夹名"
+    },
     "rss": {
       "feed": {
         "name": "名称",

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -365,7 +365,8 @@
       "not_changed": "文件名未修改",
       "fold": "收起",
       "unfold": "展开",
-      "notForFolder": "不支持修改文件夹名"
+      "notForFolder": "不支持修改文件夹名",
+      "select_regex_flags": "选择正则表达式Flags"
     },
     "rss": {
       "feed": {

--- a/src/locales/zh-Hans.json
+++ b/src/locales/zh-Hans.json
@@ -360,13 +360,13 @@
       "col_result_name": "结果",
       "run": "执行",
       "success": "重命名成功",
-      "nothing_no_do": "无任务可做",
       "duplicated": "文件名重复",
       "not_changed": "文件名未修改",
       "fold": "收起",
       "unfold": "展开",
       "notForFolder": "不支持修改文件夹名",
-      "select_regex_flags": "选择正则表达式Flags"
+      "select_regex_flags": "选择正则表达式Flags",
+      "nothing_to_do": "无任务可做"
     },
     "rss": {
       "feed": {

--- a/src/stores/content.ts
+++ b/src/stores/content.ts
@@ -28,6 +28,10 @@ export const useContentStore = defineStore('content', () => {
   const _lock = ref(false)
   const cachedFiles = ref<TorrentFile[]>([])
   const openedItems = ref([''])
+  
+  const bulkRenameRegexp = ref('')
+  const bulkRenameRegexpFlags = ref([])
+  const bulkRenameTarget = ref('')
   const { tree } = useTreeBuilder(cachedFiles)
 
   const flatTree = computed(() => {
@@ -154,6 +158,9 @@ export const useContentStore = defineStore('content', () => {
     menuData,
     cachedFiles,
     openedItems,
+    bulkRenameRegexp,
+    bulkRenameRegexpFlags,
+    bulkRenameTarget,
     tree,
     flatTree,
     updateFileTree,

--- a/src/stores/content.ts
+++ b/src/stores/content.ts
@@ -8,7 +8,7 @@ import { TorrentFile } from '@/types/qbit/models'
 import { RightClickMenuEntryType, RightClickProperties, TreeFolder, TreeNode } from '@/types/vuetorrent'
 import { useIntervalFn } from '@vueuse/core'
 import { defineStore, storeToRefs } from 'pinia'
-import { computed, nextTick, reactive, ref, watch } from 'vue'
+import { computed, nextTick, reactive, ref, toRaw, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute } from 'vue-router'
 
@@ -66,7 +66,7 @@ export const useContentStore = defineStore('content', () => {
       text: t(`torrentDetail.content.rename.bulk`),
       icon: 'mdi-rename',
       hidden: internalSelection.value.size !== 1 || (selectedNode.value?.type || 'file') === 'file',
-      action: () => bulkRename(selectedNode.value! as TreeFolder)
+      action: () => bulkRename(toRaw(selectedNode.value!) as TreeFolder)
     },
     {
       text: t(`torrentDetail.content.rename.${selectedNode.value?.type || 'file'}`),

--- a/src/stores/content.ts
+++ b/src/stores/content.ts
@@ -28,10 +28,6 @@ export const useContentStore = defineStore('content', () => {
   const _lock = ref(false)
   const cachedFiles = ref<TorrentFile[]>([])
   const openedItems = ref([''])
-  
-  const bulkRenameRegexp = ref('')
-  const bulkRenameRegexpFlags = ref([])
-  const bulkRenameTarget = ref('')
   const { tree } = useTreeBuilder(cachedFiles)
 
   const flatTree = computed(() => {
@@ -158,9 +154,6 @@ export const useContentStore = defineStore('content', () => {
     menuData,
     cachedFiles,
     openedItems,
-    bulkRenameRegexp,
-    bulkRenameRegexpFlags,
-    bulkRenameTarget,
     tree,
     flatTree,
     updateFileTree,

--- a/src/stores/content.ts
+++ b/src/stores/content.ts
@@ -5,7 +5,7 @@ import { useDialogStore } from '@/stores/dialog'
 import { useMaindataStore } from '@/stores/maindata'
 import { useVueTorrentStore } from '@/stores/vuetorrent'
 import { TorrentFile } from '@/types/qbit/models'
-import { RightClickMenuEntryType, RightClickProperties, TreeNode } from '@/types/vuetorrent'
+import { RightClickMenuEntryType, RightClickProperties, TreeFolder, TreeNode } from '@/types/vuetorrent'
 import { useIntervalFn } from '@vueuse/core'
 import { defineStore, storeToRefs } from 'pinia'
 import { computed, nextTick, reactive, ref, watch } from 'vue'
@@ -65,8 +65,8 @@ export const useContentStore = defineStore('content', () => {
     {
       text: t(`torrentDetail.content.rename.bulk`),
       icon: 'mdi-rename',
-      hidden: true, // internalSelection.value.size <= 1
-      action: bulkRename
+      hidden: internalSelection.value.size !== 1 || (selectedNode.value?.type || 'file') === 'file',
+      action: () => bulkRename(selectedNode.value! as TreeFolder)
     },
     {
       text: t(`torrentDetail.content.rename.${selectedNode.value?.type || 'file'}`),
@@ -118,8 +118,12 @@ export const useContentStore = defineStore('content', () => {
     renameDialog.value = dialogStore.createDialog(MoveTorrentFileDialog, renamePayload)
   }
 
-  async function bulkRename() {
-    //TODO
+  async function bulkRename(node: TreeFolder) {
+    const { default: BulkRenameFilesDialog } = await import('@/components/Dialogs/BulkRenameFilesDialog.vue')
+    renameDialog.value = dialogStore.createDialog(BulkRenameFilesDialog, {
+      hash: hash.value,
+      node
+    })
   }
 
   async function renameTorrentFile(hash: string, oldPath: string, newPath: string) {

--- a/src/stores/vuetorrent.ts
+++ b/src/stores/vuetorrent.ts
@@ -35,6 +35,9 @@ export const useVueTorrentStore = defineStore(
     const refreshInterval = ref(2000)
     const fileContentInterval = ref(5000)
     const useIdForRssLinks = ref(false)
+    const bulkRenameRegexp = ref('')
+    const bulkRenameRegexpFlags = ref([])
+    const bulkRenameTarget = ref('')
 
     const _busyProperties = ref<PropertyData>(JSON.parse(JSON.stringify(propsData)))
     const _doneProperties = ref<PropertyData>(JSON.parse(JSON.stringify(propsData)))
@@ -239,6 +242,9 @@ export const useVueTorrentStore = defineStore(
       useBinarySize,
       useBitSpeed,
       useIdForRssLinks,
+      bulkRenameRegexp,
+      bulkRenameRegexpFlags,
+      bulkRenameTarget,
       _busyProperties,
       busyTorrentProperties,
       _doneProperties,

--- a/src/stores/vuetorrent.ts
+++ b/src/stores/vuetorrent.ts
@@ -35,9 +35,6 @@ export const useVueTorrentStore = defineStore(
     const refreshInterval = ref(2000)
     const fileContentInterval = ref(5000)
     const useIdForRssLinks = ref(false)
-    const bulkRenameRegexp = ref('')
-    const bulkRenameRegexpFlags = ref([])
-    const bulkRenameTarget = ref('')
 
     const _busyProperties = ref<PropertyData>(JSON.parse(JSON.stringify(propsData)))
     const _doneProperties = ref<PropertyData>(JSON.parse(JSON.stringify(propsData)))
@@ -242,9 +239,6 @@ export const useVueTorrentStore = defineStore(
       useBinarySize,
       useBitSpeed,
       useIdForRssLinks,
-      bulkRenameRegexp,
-      bulkRenameRegexpFlags,
-      bulkRenameTarget,
       _busyProperties,
       busyTorrentProperties,
       _doneProperties,


### PR DESCRIPTION
# feat(TorrentDetail): add bulk renaming


https://github.com/VueTorrent/VueTorrent/assets/45785585/af75ef38-4606-4406-be48-e8c02ea66686

For #895.

The main functions are primarily referenced from https://github.com/qbittorrent/qBittorrent/pull/18287.

**Features**:
- Using regular expressions to handle renaming, supporting flags
- Expand/collapse folders, partial selection
- Identifying duplicate file names
- Identifying renaming result conflicts with original name

**Limitations**:
- Unable to rename folders
- Regular expressions only apply to file name and cannot be applied to the full path


## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
