### PR TITLE
feat: add peer clients to TorrentDetail

### DIFF
--- a/src/components/TorrentDetail/Peers.vue
+++ b/src/components/TorrentDetail/Peers.vue
@@ -86,6 +86,8 @@ watch(() => props.isActive, setupTimer)
                 Flags: <span class="cursor-help" :title="peer.flags_desc">{{ peer.flags }}</span>
               </div>
 
+              <div>Client: {{ peer.client }}</div>
+
               <div>Progress: {{ formatPercent(peer.progress) }}</div>
 
               <div>


### PR DESCRIPTION
# feat: add peer clients to TorrentDetail 

Add the missing peer client info which is included in the official web UI.

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
