### PR TITLE
perf(Content): Better handle tree filtering

### DIFF
--- a/src/components/TorrentDetail/Content/Content.vue
+++ b/src/components/TorrentDetail/Content/Content.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useSearchQuery } from '@/composables'
 import { useContentStore } from '@/stores'
 import { Torrent, TreeNode } from '@/types/vuetorrent'
 import { storeToRefs } from 'pinia'
@@ -11,11 +10,7 @@ const props = defineProps<{ torrent: Torrent; isActive: boolean }>()
 
 const { height: deviceHeight } = useDisplay()
 const contentStore = useContentStore()
-const { rightClickProperties, openedItems, flatTree, internalSelection } = storeToRefs(contentStore)
-
-const filter = ref<string>('')
-
-const { results: filteredTree } = useSearchQuery(flatTree, filter, item => item.fullName)
+const { rightClickProperties, filenameFilter, openedItems, flatTree, internalSelection } = storeToRefs(contentStore)
 
 const height = computed(() => {
   // 48px for the tabs and page title
@@ -60,9 +55,9 @@ function endPress() {
 
 <template>
   <v-card>
-    <v-text-field v-model="filter" class="mt-2 mx-3" hide-details clearable :placeholder="$t('torrentDetail.content.filter_placeholder')" />
+    <v-text-field v-model="filenameFilter" class="mt-2 mx-3" hide-details clearable :placeholder="$t('torrentDetail.content.filter_placeholder')" />
 
-    <v-virtual-scroll id="tree-root" :items="filteredTree" :height="height" item-height="68" class="pa-2">
+    <v-virtual-scroll id="tree-root" :items="flatTree" :height="height" item-height="68" class="pa-2">
       <template #default="{ item }">
         <ContentNode
           :opened-items="openedItems"

--- a/src/stores/content.ts
+++ b/src/stores/content.ts
@@ -1,4 +1,4 @@
-import { useTreeBuilder } from '@/composables'
+import {useSearchQuery, useTreeBuilder} from '@/composables'
 import { FilePriority } from '@/constants/qbit'
 import { qbit } from '@/services'
 import { useDialogStore } from '@/stores/dialog'
@@ -26,9 +26,11 @@ export const useContentStore = defineStore('content', () => {
     offset: [0, 0]
   })
   const _lock = ref(false)
+  const filenameFilter = ref('')
   const cachedFiles = ref<TorrentFile[]>([])
   const openedItems = ref([''])
-  const { tree } = useTreeBuilder(cachedFiles)
+  const { results: filteredFiles } = useSearchQuery(cachedFiles, filenameFilter, item => item.name)
+  const { tree } = useTreeBuilder(filteredFiles)
 
   const flatTree = computed(() => {
     const flatten = (node: TreeNode, parentPath: string): TreeNode[] => {
@@ -148,8 +150,10 @@ export const useContentStore = defineStore('content', () => {
     rightClickProperties,
     internalSelection,
     menuData,
+    filenameFilter,
     cachedFiles,
     openedItems,
+    filteredFiles,
     tree,
     flatTree,
     updateFileTree,
@@ -161,6 +165,7 @@ export const useContentStore = defineStore('content', () => {
     $reset: () => {
       while (_lock.value) {}
       internalSelection.value.clear()
+      filenameFilter.value = ''
       cachedFiles.value = []
       openedItems.value = ['']
       pauseTimer()


### PR DESCRIPTION
Not sure about the PR title.

Basically I moved the filtering before the tree generation.

Actual behaviour:

`cachedFiles -> tree -> flatTree -> filteredTree`

This would cause a lot of issues:
- directory should be opened to filter its children
  - This could add a lot of overhead and user actions on large torrents
- Filtering were applied on list entities
  - This would hide the parent objects of a matching file
- Folder actions were not using the filter
  - When marking a folder to download / changing priority, every child would be impacted regardless of the filter
- There were probably other stuff that were not convenient

New behaviour:

`cachedFiles -> filteredFiles -> tree -> flatTree`

By placing the filter before the tree generation allows for displaying the whole child structure of the filtering results as `cachedFiles` contain a list of files. Once all files are filtered we generate the structure.