### PR TITLE
chore(deps): Bump vuetify from 3.5.17 to 3.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "vue3-apexcharts": "^1.5.2",
         "vue3-toastify": "^0.2.1",
         "vuedraggable": "^4.1.0",
-        "vuetify": "^3.5.17"
+        "vuetify": "^3.6.3"
       },
       "devDependencies": {
         "@pinia/testing": "^0.1.3",
@@ -5346,9 +5346,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.5.17.tgz",
-      "integrity": "sha512-/Veklxxyu/l63q7QQOqJZeZukIKI2sBxY7FKMDcNup2KSGMjyjT+oYXy1DOdl7wlU3c3fKGQMFHqVWb0HDsyDw==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.6.3.tgz",
+      "integrity": "sha512-OBYYJYnNeUYA7kwrv8Rag1EBFbGWAQxJpp0s98U2KQ6SPU7MzzcrvNn7t69vcDbj7mR7Dcf9/jvFapfranXZvA==",
       "engines": {
         "node": "^12.20 || >=14.13"
       },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "vue3-apexcharts": "^1.5.2",
     "vue3-toastify": "^0.2.1",
     "vuedraggable": "^4.1.0",
-    "vuetify": "^3.5.17"
+    "vuetify": "^3.6.3"
   },
   "devDependencies": {
     "@pinia/testing": "^0.1.3",

--- a/src/components/Dialogs/PluginManagerDialog.vue
+++ b/src/components/Dialogs/PluginManagerDialog.vue
@@ -83,11 +83,15 @@ function closeInstallDialog() {
 
         <v-spacer />
 
-        <v-btn :text="$t('dialogs.pluginManager.update')" color="accent" class="mr-2" :loading="updateLoading" @click="updatePlugins" />
+        <v-btn :icon="$vuetify.display.mobile" color="accent" class="mr-2" :loading="updateLoading" @click="updatePlugins">
+          <v-icon v-if="$vuetify.display.mobile">mdi-update</v-icon>
+          <span v-else>{{ $t('dialogs.pluginManager.update') }}</span>
+        </v-btn>
         <v-dialog v-model="installisOpened">
           <template v-slot:activator="{ props }">
-            <v-btn v-bind="props" color="primary">
-              {{ $t('dialogs.pluginManager.install.activator') }}
+            <v-btn v-bind="props" :icon="$vuetify.display.mobile" color="primary">
+              <v-icon v-if="$vuetify.display.mobile">mdi-toy-brick-plus</v-icon>
+              <span v-else>{{ $t('dialogs.pluginManager.install.activator') }}</span>
             </v-btn>
           </template>
 
@@ -107,16 +111,15 @@ function closeInstallDialog() {
       </v-card-title>
       <v-card-text>
         <v-data-table :headers="headers" items-per-page="-1" :items="searchEngineStore.searchPlugins" :sort-by="[{ key: 'fullName', order: 'asc' }]" :loading="loading">
-          <template v-slot:item.enabled="{ item }">
+          <template v-slot:[`item.enabled`]="{ item }">
             <v-checkbox-btn :model-value="item.enabled" @click="onTogglePlugin(item)" />
           </template>
-          <template v-slot:item.url="{ item }">
+          <template v-slot:[`item.url`]="{ item }">
             <a :href="item.url" :title="item.name">{{ item.url }}</a>
           </template>
-          <template v-slot:item.actions="{ item }">
+          <template v-slot:[`item.actions`]="{ item }">
             <v-icon color="red" icon="mdi-delete" @click="uninstallPlugin(item)" />
           </template>
-          <template v-slot:tfoot></template>
         </v-data-table>
       </v-card-text>
       <v-card-actions>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -293,6 +293,7 @@
       "col_origin_name": "Original",
       "col_result_name": "Result",
       "duplicated": "Duplicate Filename",
+      "flags": "Flags",
       "fold": "Collapse",
       "not_changed": "Filename Not Changed",
       "notForFolder": "Folder Renaming Not Supported",

--- a/src/pages/SearchEngine.vue
+++ b/src/pages/SearchEngine.vue
@@ -240,10 +240,10 @@ onBeforeUnmount(() => {
               </v-col>
             </v-row>
           </template>
-          <template v-slot:item.fileSize="{ item }">
+          <template v-slot:[`item.fileSize`]="{ item }">
             {{ formatData(item.fileSize, vuetorrentStore.useBinarySize) }}
           </template>
-          <template v-slot:item.actions="{ item }">
+          <template v-slot:[`item.actions`]="{ item }">
             <v-btn icon="mdi-open-in-new" variant="flat" density="compact" @click.stop="openLink(item)" />
             <v-btn icon="mdi-download" variant="flat" density="compact" @click="downloadTorrent(item)"></v-btn>
           </template>

--- a/src/services/MockProvider.ts
+++ b/src/services/MockProvider.ts
@@ -810,7 +810,48 @@ export default class MockProvider implements IProvider {
           priority: FilePriority.NORMAL,
           progress: 0,
           size: 5173995520
-        }
+        },
+        {
+          availability: 1,
+          index: 1,
+          is_seed: false,
+          name: 'ubuntu-24.10.1-desktop-amd64.iso',
+          piece_range: [0, 63],
+          priority: FilePriority.NORMAL,
+          progress: 0,
+          size: 5173995520
+        },
+        {
+          availability: 1,
+          index: 2,
+          is_seed: false,
+          name: 'ubuntu/ubuntu-23.10.1-desktop-amd64.iso',
+          piece_range: [0, 63],
+          priority: FilePriority.NORMAL,
+          progress: 0,
+          size: 5173995520
+        },
+        {
+          availability: 1,
+          index: 3,
+          is_seed: false,
+          name: 'ubuntu/ubuntu-24.10.1-desktop-amd64.iso',
+          piece_range: [0, 63],
+          priority: FilePriority.NORMAL,
+          progress: 0,
+          size: 5173995520
+        },
+        {
+          availability: 1,
+          index: 5,
+          is_seed: false,
+          name: 'ubuntu2/ubuntu-23.10.1-desktop-amd64.iso',
+          piece_range: [0, 63],
+          priority: FilePriority.NORMAL,
+          progress: 0,
+          size: 5173995520
+        },
+
       ]
     })
   }


### PR DESCRIPTION
* Mobile data tables are here!
* Clean BulkRenameFilesDialog, improve mobile layout and add missing key
  * New mobile data table made the mobile layout completely unusable, had to rework it to simplify and make it usable again
  * Other data tables were a lot simplier thus changes weren't needed

Old layout:
![image](https://github.com/VueTorrent/VueTorrent/assets/22910497/abee253c-dbdd-436a-b9f0-16bc483bd42b)


New layout:
![image](https://github.com/VueTorrent/VueTorrent/assets/22910497/f710e9a2-7243-4e95-92b6-07261de01e4f)
