### PR TITLE
chore(deps): Bump vuetify from 3.6.3 to 3.6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The sleekest looking WebUI for qBittorrent made with Vue.js!
 
 ![VueTorrent](https://cdn.jsdelivr.net/gh/VueTorrent/VueTorrent@master/VueTorrent-logo.png)
 
-![Vue](https://img.shields.io/badge/Vue-%5E3.4.20-brightgreen) ![Vuetify](https://img.shields.io/badge/Vuetify-%5E3.5.6-brightgreen)
+![Vue](https://img.shields.io/badge/Vue-%5E3.4.26-brightgreen) ![Vuetify](https://img.shields.io/badge/Vuetify-%5E3.6.4-brightgreen)
 ![qBittorrent](https://img.shields.io/badge/qBittorrent-4.4%2B-brightgreen)
 
 ![stars](https://img.shields.io/github/stars/VueTorrent/VueTorrent) ![Forks](https://img.shields.io/github/forks/VueTorrent/VueTorrent)

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "vue3-apexcharts": "^1.5.2",
         "vue3-toastify": "^0.2.1",
         "vuedraggable": "^4.1.0",
-        "vuetify": "^3.6.3"
+        "vuetify": "^3.6.4"
       },
       "devDependencies": {
         "@pinia/testing": "^0.1.3",
@@ -5346,9 +5346,9 @@
       }
     },
     "node_modules/vuetify": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.6.3.tgz",
-      "integrity": "sha512-OBYYJYnNeUYA7kwrv8Rag1EBFbGWAQxJpp0s98U2KQ6SPU7MzzcrvNn7t69vcDbj7mR7Dcf9/jvFapfranXZvA==",
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.6.4.tgz",
+      "integrity": "sha512-H0s+VQAuFDIaqJaxaYv3DuJoSlThMfIJX5l06sGkxk9YDMxiEjE4ABT58fTAZGdPMF/TzMXtTHbRNCHes0UaHQ==",
       "engines": {
         "node": "^12.20 || >=14.13"
       },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "vue3-apexcharts": "^1.5.2",
     "vue3-toastify": "^0.2.1",
     "vuedraggable": "^4.1.0",
-    "vuetify": "^3.6.3"
+    "vuetify": "^3.6.4"
   },
   "devDependencies": {
     "@pinia/testing": "^0.1.3",

--- a/src/components/Dialogs/PluginManagerDialog.vue
+++ b/src/components/Dialogs/PluginManagerDialog.vue
@@ -110,7 +110,7 @@ function closeInstallDialog() {
         </v-dialog>
       </v-card-title>
       <v-card-text>
-        <v-data-table :headers="headers" items-per-page="-1" :items="searchEngineStore.searchPlugins" :sort-by="[{ key: 'fullName', order: 'asc' }]" :loading="loading">
+        <v-data-table :mobile="null" :headers="headers" items-per-page="-1" :items="searchEngineStore.searchPlugins" :sort-by="[{ key: 'fullName', order: 'asc' }]" :loading="loading">
           <template v-slot:[`item.enabled`]="{ item }">
             <v-checkbox-btn :model-value="item.enabled" @click="onTogglePlugin(item)" />
           </template>

--- a/src/components/Settings/Downloads.vue
+++ b/src/components/Settings/Downloads.vue
@@ -244,7 +244,7 @@ const closeDeleteDialog = async () => {
 
     <v-divider />
 
-    <v-data-table class="my-4" :headers="monitoredFoldersHeaders" :items="monitoredFoldersData">
+    <v-data-table :mobile="null" class="my-4" :headers="monitoredFoldersHeaders" :items="monitoredFoldersData">
       <template v-slot:top>
         <v-toolbar flat>
           <v-toolbar-title>{{ t('settings.downloads.monitoredFolders.subheader') }}</v-toolbar-title>

--- a/src/pages/SearchEngine.vue
+++ b/src/pages/SearchEngine.vue
@@ -232,7 +232,7 @@ onBeforeUnmount(() => {
       <v-divider class="my-3" />
 
       <v-list-item class="text-select">
-        <v-data-table :headers="headers" :items="filteredResults" :footer-props="{ itemsPerPageOptions: [10, 25, 50, 100, -1] }" :items-per-page.sync="selectedTab.itemsPerPage">
+        <v-data-table :mobile="null" :headers="headers" :items="filteredResults" :footer-props="{ itemsPerPageOptions: [10, 25, 50, 100, -1] }" :items-per-page.sync="selectedTab.itemsPerPage">
           <template v-slot:top>
             <v-row>
               <v-col cols="12">


### PR DESCRIPTION
Mobile data tables has been disabled by default in the latest version