### PR TITLE
feat(RSS): add refresh all rss feeds button to rss articles

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -549,6 +549,12 @@
       "pending": "Marking...",
       "success": "{n} articles marked as read"
     },
+    "refreshAllFeeds": "Refresh All Feeds",
+    "refreshPromise": {
+      "error": "An error occured while refreshing feeds",
+      "pending": "Refreshing...",
+      "success": "{n} feeds refreshed"
+    },
     "title": "RSS Articles"
   },
   "searchEngine": {

--- a/src/pages/RssArticles.vue
+++ b/src/pages/RssArticles.vue
@@ -106,9 +106,10 @@ onUnmounted(() => {
             <div class="d-flex flex-row align-center justify-center">
               <v-checkbox v-model="rssStore.filters.unread" :label="$t('rssArticles.filters.unread')" hide-details />
               <v-spacer />
-              <v-btn :disabled="rssStore.unreadArticles.length === 0" :text="$t('rssArticles.markAllAsRead')" color="primary" @click="rssStore.markAllAsRead()" />
-              &nbsp;
-              <v-btn :disabled="rssStore.feeds.length === 0" :text="$t('rssArticles.refreshAllFeeds')" color="primary" @click="rssStore.refreshAllFeeds()" />
+              <div :class="{'d-flex button-group': true, 'flex-column': $vuetify.display.mobile}">
+                <v-btn :disabled="rssStore.unreadArticles.length === 0" :text="$t('rssArticles.markAllAsRead')" color="primary" @click="rssStore.markAllAsRead()" />
+                <v-btn :disabled="rssStore.feeds.length === 0" :text="$t('rssArticles.refreshAllFeeds')" color="primary" @click="rssStore.refreshAllFeeds()" />
+              </div>
             </div>
           </v-col>
         </v-row>
@@ -188,6 +189,10 @@ onUnmounted(() => {
 
 .description-container {
   border: solid red 5px;
+}
+
+.button-group {
+  gap: 8px;
 }
 </style>
 

--- a/src/pages/RssArticles.vue
+++ b/src/pages/RssArticles.vue
@@ -107,6 +107,8 @@ onUnmounted(() => {
               <v-checkbox v-model="rssStore.filters.unread" :label="$t('rssArticles.filters.unread')" hide-details />
               <v-spacer />
               <v-btn :disabled="rssStore.unreadArticles.length === 0" :text="$t('rssArticles.markAllAsRead')" color="primary" @click="rssStore.markAllAsRead()" />
+              &nbsp;
+              <v-btn :disabled="rssStore.feeds.length === 0" :text="$t('rssArticles.refreshAllFeeds')" color="primary" @click="rssStore.refreshAllFeeds()" />
             </div>
           </v-col>
         </v-row>

--- a/src/stores/rss.ts
+++ b/src/stores/rss.ts
@@ -30,6 +30,22 @@ export const useRssStore = defineStore(
       await qbit.refreshFeed(feedName)
     }
 
+    async function refreshAllFeeds() {
+      await toast.promise(
+        Promise.all(feeds.value.map(feed => refreshFeed(feed.name))),
+        {
+          pending: t('rssArticles.refreshPromise.pending'),
+          error: t('rssArticles.refreshPromise.error'),
+          success: t('rssArticles.refreshPromise.success', feeds.value.length)
+        },
+        {
+          autoClose: 1500
+        }
+      )
+
+      await fetchFeeds()
+    }
+
     async function createFeed(feedName: string, feedUrl: string) {
       await qbit.createFeed({ name: feedName, url: feedUrl })
     }
@@ -140,6 +156,7 @@ export const useRssStore = defineStore(
       articles,
       unreadArticles,
       refreshFeed,
+      refreshAllFeeds,
       createFeed,
       setRule,
       renameFeed,


### PR DESCRIPTION
# feat: add 'refresh all rss feeds' button to rss articles page

Fixes #1586. Simply adds a new `refreshAllFeeds()` to the rss store, complete with toast notification. Only thing missing are other translations, it only pulls from `en` right now.

First time using vue, it's very possible I messed up something obvious.

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
