### PR TITLE
fix(filters): "Untagged" value don't using tracker filter when matched

### DIFF
--- a/src/components/TorrentDetail/Peers.vue
+++ b/src/components/TorrentDetail/Peers.vue
@@ -206,10 +206,11 @@ onBeforeRouteLeave(() => !addPeersDialog.value)
         </template>
         <v-card :title="$t('torrentDetail.peers.addPeers.title')">
           <v-card-text>
-            <v-textarea v-model="newPeers"
-                        :label="t('torrentDetail.peers.addPeers.newPeers')"
-                        :placeholder="t('torrentDetail.peers.addPeers.newPeersPlaceholder')"
-                        :hint="t('torrentDetail.peers.addPeers.newPeersHint')" />
+            <v-textarea
+              v-model="newPeers"
+              :label="t('torrentDetail.peers.addPeers.newPeers')"
+              :placeholder="t('torrentDetail.peers.addPeers.newPeersPlaceholder')"
+              :hint="t('torrentDetail.peers.addPeers.newPeersHint')" />
           </v-card-text>
 
           <v-card-actions>

--- a/src/services/qbit/MockProvider.ts
+++ b/src/services/qbit/MockProvider.ts
@@ -1413,10 +1413,12 @@ export default class MockProvider implements IProvider {
 
   async getCategories(): Promise<Category[]> {
     return this.generateResponse({
-      result: this.categories.filter(x => x).map(cat => ({
-        name: cat,
-        savePath: `/downloads/${cat.toLowerCase()}`
-      }))
+      result: this.categories
+        .filter(x => x)
+        .map(cat => ({
+          name: cat,
+          savePath: `/downloads/${cat.toLowerCase()}`
+        }))
     })
   }
 

--- a/src/services/qbit/MockProvider.ts
+++ b/src/services/qbit/MockProvider.ts
@@ -24,6 +24,8 @@ import IProvider from './IProvider'
 
 export default class MockProvider implements IProvider {
   private static instance: MockProvider
+  private readonly categories = ['', 'ISO', 'Other', 'Movie', 'Music', 'TV']
+  private readonly trackers = ['', ...faker.helpers.multiple(() => faker.internet.url(), { count: 5 })]
   private static hashes: string[] = Array(parseInt(import.meta.env.VITE_FAKE_TORRENTS_COUNT || 15))
     .fill('')
     .map((_, i) => (i + 1).toString(16).padStart(40, '0'))
@@ -1065,14 +1067,14 @@ export default class MockProvider implements IProvider {
       const state = faker.helpers.enumValue(TorrentState)
       const total_size = faker.number.int({ min: 1_000_000, max: 1_000_000_000_000 }) // [1 Mo; 1 To]
       const completed = faker.number.int({ min: 0, max: total_size })
-      const tracker = faker.internet.url()
+      const tracker = faker.helpers.arrayElement(this.trackers)
 
       return {
         added_on,
         amount_left: faker.number.int({ min: 0, max: total_size }),
         auto_tmm: faker.datatype.boolean(),
         availability: faker.number.float({ min: 0, max: 100, multipleOf: 0.01 }),
-        category: faker.helpers.arrayElement(['ISO', 'Other', 'Movie', 'Music', 'TV']),
+        category: faker.helpers.arrayElement(this.categories),
         completed,
         completion_on: faker.date.between({ from: added_on, to: Date.now() }).getTime() / 1000,
         content_path: faker.system.filePath(),
@@ -1411,10 +1413,10 @@ export default class MockProvider implements IProvider {
 
   async getCategories(): Promise<Category[]> {
     return this.generateResponse({
-      result: [
-        { name: 'Movies', savePath: '/downloads/movies' },
-        { name: 'Series', savePath: '/downloads/series' }
-      ]
+      result: this.categories.filter(x => x).map(cat => ({
+        name: cat,
+        savePath: `/downloads/${cat.toLowerCase()}`
+      }))
     })
   }
 

--- a/src/stores/torrents.ts
+++ b/src/stores/torrents.ts
@@ -4,6 +4,7 @@ import { extractHostname } from '@/helpers'
 import qbit from '@/services/qbit'
 import { AddTorrentPayload, GetTorrentPayload } from '@/types/qbit/payloads'
 import { Torrent } from '@/types/vuetorrent'
+import { useArrayFilter } from '@vueuse/core'
 import { defineStore } from 'pinia'
 import { computed, MaybeRefOrGetter, reactive, ref, toValue } from 'vue'
 
@@ -24,18 +25,16 @@ export const useTorrentStore = defineStore(
     const tagFilter = ref<(string | null)[]>([])
     const trackerFilter = ref<(string | null)[]>([])
 
-    const torrentsWithFilters = computed(() => {
-      return torrents.value.filter(torrent => {
-        if (statusFilter.value.length > 0 && isStatusFilterActive.value && !statusFilter.value.includes(torrent.state)) return false
-        if (categoryFilter.value.length > 0 && isCategoryFilterActive.value && !categoryFilter.value.includes(torrent.category)) return false
-        if (tagFilter.value.length > 0 && isTagFilterActive.value) {
-          if (torrent.tags.length === 0 && tagFilter.value.includes(null)) return true
-          if (!torrent.tags.some(tag => tagFilter.value.includes(tag))) return false
-        }
-        if (trackerFilter.value.length > 0 && isTrackerFilterActive.value && !trackerFilter.value.includes(extractHostname(torrent.tracker))) return false
+    const torrentsWithFilters = useArrayFilter(torrents, torrent => {
+      if (statusFilter.value.length > 0 && isStatusFilterActive.value && !statusFilter.value.includes(torrent.state)) return false
+      if (categoryFilter.value.length > 0 && isCategoryFilterActive.value && !categoryFilter.value.includes(torrent.category)) return false
+      if (tagFilter.value.length > 0 && isTagFilterActive.value) {
+        if (torrent.tags.length === 0 && !tagFilter.value.includes(null)) return false
+        if (!torrent.tags.some(tag => tagFilter.value.includes(tag))) return false
+      }
+      if (trackerFilter.value.length > 0 && isTrackerFilterActive.value && !trackerFilter.value.includes(extractHostname(torrent.tracker))) return false
 
-        return true
-      })
+      return true
     })
     const filteredTorrents = computed(() => searchQuery.results.value)
 

--- a/src/stores/torrents.ts
+++ b/src/stores/torrents.ts
@@ -30,7 +30,7 @@ export const useTorrentStore = defineStore(
       if (categoryFilter.value.length > 0 && isCategoryFilterActive.value && !categoryFilter.value.includes(torrent.category)) return false
       if (tagFilter.value.length > 0 && isTagFilterActive.value) {
         if (torrent.tags.length === 0 && !tagFilter.value.includes(null)) return false
-        if (!torrent.tags.some(tag => tagFilter.value.includes(tag))) return false
+        if (torrent.tags.length > 0 && !torrent.tags.some(tag => tagFilter.value.includes(tag))) return false
       }
       if (trackerFilter.value.length > 0 && isTrackerFilterActive.value && !trackerFilter.value.includes(extractHostname(torrent.tracker))) return false
 


### PR DESCRIPTION
Bug was found on Discord by @krysalysm

Current behaviour:
- Only Tracker filter: 45 torrents
- Tracker and named tag: 33 torrents
- Tracker and untagged: **223** torrents (all untagged torrents)

Fixed behaviour:
- Only Tracker filter: 45 torrents
- Tracker and named tag: 33 torrents
- Tracker and untagged: **12** torrents