### PR TITLE
feat(tags): option to have tags/categories without the “pill” shape (#1492)

### DIFF
--- a/src/components/Core/ColoredChip.vue
+++ b/src/components/Core/ColoredChip.vue
@@ -18,14 +18,15 @@ const props = withDefaults(
 )
 
 const { t } = useI18n()
-const { enableHashColors } = storeToRefs(useVueTorrentStore())
+const { enableHashColors, hideColoredChip } = storeToRefs(useVueTorrentStore())
 
 const chipColor = computed(() => (props.disabled || !enableHashColors.value ? props.defaultColor : getColorFromName(props.value)))
 const chipValue = computed(() => (props.disabled ? props.disabledValue || t('common.none') : props.value))
+const shouldShowColoredChips = computed(() => !hideColoredChip.value)
 </script>
 
 <template>
-  <v-chip :color="chipColor" variant="flat">
+  <v-chip :color="chipColor" :variant="shouldShowColoredChips ? 'flat' : 'text'">
     {{ chipValue }}
   </v-chip>
 </template>

--- a/src/components/Dashboard/DashboardItems/ItemChip.vue
+++ b/src/components/Dashboard/DashboardItems/ItemChip.vue
@@ -19,11 +19,12 @@ const props = withDefaults(
   }
 )
 
-const { hideChipIfUnset, enableHashColors } = storeToRefs(useVueTorrentStore())
+const { hideChipIfUnset, enableHashColors, hideColoredChip } = storeToRefs(useVueTorrentStore())
 
 const val = computed(() => props.value(props.torrent))
 const emptyValue = computed(() => val.value.length < 1 || val.value[0] === '')
 const shouldShowChip = computed(() => !(hideChipIfUnset.value && emptyValue.value))
+const shouldShowColoredChips = computed(() => !hideColoredChip.value)
 const useRandomColor = computed(() => enableHashColors.value && props.enableHashColor)
 </script>
 
@@ -33,10 +34,10 @@ const useRandomColor = computed(() => enableHashColors.value && props.enableHash
       {{ $t(titleKey) }}
     </div>
     <div class="d-flex flex-row flex-gap-column-small">
-      <v-chip v-if="emptyValue" :color="color(torrent)" variant="flat" size="small">
+      <v-chip v-if="emptyValue" :color="color(torrent)" :variant="shouldShowColoredChips ? 'flat' : 'text'" size="small">
         {{ $t(emptyValueKey) }}
       </v-chip>
-      <v-chip v-else v-for="v in val" :color="useRandomColor ? getColorFromName(v) : color(torrent)" variant="flat" size="small">
+      <v-chip v-else v-for="v in val" :color="useRandomColor ? getColorFromName(v) : color(torrent)" :variant="shouldShowColoredChips ? 'flat' : 'text'" size="small">
         {{ v }}
       </v-chip>
     </div>

--- a/src/components/Dashboard/Views/Table/DashboardItems/ItemChip.vue
+++ b/src/components/Dashboard/Views/Table/DashboardItems/ItemChip.vue
@@ -18,21 +18,22 @@ const props = withDefaults(
   }
 )
 
-const { hideChipIfUnset, enableHashColors } = storeToRefs(useVueTorrentStore())
+const { hideChipIfUnset, enableHashColors, hideColoredChip } = storeToRefs(useVueTorrentStore())
 
 const val = computed(() => props.value(props.torrent))
 const emptyValue = computed(() => val.value.length < 1 || val.value[0] === '')
 const shouldShowChip = computed(() => !(hideChipIfUnset.value && emptyValue.value))
+const shouldShowColoredChips = computed(() => !hideColoredChip.value)
 const useRandomColor = computed(() => enableHashColors.value && props.enableHashColor)
 </script>
 
 <template>
   <td>
     <div class="d-flex flex-row flex-gap-column-small" v-if="shouldShowChip">
-      <v-chip v-if="emptyValue" :color="color(torrent)" variant="flat" size="small">
+      <v-chip v-if="emptyValue" :color="color(torrent)" :variant="shouldShowColoredChips ? 'flat' : 'text'" size="small">
         {{ $t(emptyValueKey) }}
       </v-chip>
-      <v-chip v-else v-for="v in val" :color="useRandomColor ? getColorFromName(v) : color(torrent)" variant="flat" size="small">
+      <v-chip v-else v-for="v in val" :color="useRandomColor ? getColorFromName(v) : color(torrent)" :variant="shouldShowColoredChips ? 'flat' : 'text'" size="small">
         {{ v }}
       </v-chip>
     </div>

--- a/src/components/Settings/VueTorrent/General.vue
+++ b/src/components/Settings/VueTorrent/General.vue
@@ -168,7 +168,9 @@ onBeforeMount(() => {
         <v-col cols="12" sm="6">
           <v-checkbox v-model="vueTorrentStore.hideChipIfUnset" hide-details density="compact" :label="t('settings.vuetorrent.general.hideChipIfUnset')" />
         </v-col>
-        <v-col cols="12" sm="6" />
+        <v-col cols="12" sm="6">
+          <v-checkbox v-model="vueTorrentStore.hideColoredChip" hide-details density="compact" :label="t('settings.vuetorrent.general.hideColoredChip')" />
+        </v-col>
 
         <v-col cols="12" sm="6">
           <v-checkbox v-model="vueTorrentStore.openSideBarOnStart" hide-details density="compact" :label="t('settings.vuetorrent.general.openSideBarOnStart')" />

--- a/src/components/TorrentDetail/Overview.vue
+++ b/src/components/TorrentDetail/Overview.vue
@@ -40,6 +40,8 @@ const ratioColor = computed(() => {
   return getRatioColor(props.torrent.ratio)
 })
 
+const shouldShowColoredChips = computed(() => !vuetorrentStore.hideColoredChip)
+
 async function copyHash() {
   try {
     await navigator.clipboard.writeText(props.torrent.hash)
@@ -189,7 +191,7 @@ onUnmounted(async () => {
           <v-row>
             <v-col cols="6">
               <div>{{ $t('torrent.properties.state') }}:</div>
-              <v-chip variant="flat" :color="torrentStateColor">{{ $t(`torrent.state.${torrent.state}`) }}</v-chip>
+              <v-chip :variant="shouldShowColoredChips ? 'flat' : 'text'" :color="torrentStateColor">{{ $t(`torrent.state.${torrent.state}`) }}</v-chip>
             </v-col>
             <v-col cols="6">
               <div>{{ $t('torrent.properties.category') }}:</div>
@@ -207,7 +209,7 @@ onUnmounted(async () => {
               <div v-if="torrent.tags.length" class="d-flex flex-wrap flex-gap-row-small flex-gap-column">
                 <ColoredChip v-for="tag in torrent.tags" default-color="tag" :value="tag" />
               </div>
-              <v-chip v-else variant="flat" color="tag">
+              <v-chip v-else :variant="shouldShowColoredChips ? 'flat' : 'text'" color="tag">
                 {{ $t('navbar.side.filters.untagged') }}
               </v-chip>
             </v-col>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -971,6 +971,7 @@
         "enableRatioColors": "Enable ratio colors",
         "fileContentInterval": "Torrent file content refresh interval",
         "hideChipIfUnset": "Hide chips if unset",
+        "hideColoredChip": "Use text variant for chips",
         "historySize": "History size on eligible fields",
         "import": "Import Settings",
         "isDrawerRight": "Right Drawer",

--- a/src/stores/vuetorrent.ts
+++ b/src/stores/vuetorrent.ts
@@ -43,6 +43,7 @@ export const useVueTorrentStore = defineStore(
     const refreshInterval = ref(2000)
     const fileContentInterval = ref(5000)
     const useIdForRssLinks = ref(false)
+    const hideColoredChip = ref(false)
 
     const _busyProperties = ref<PropertyData>(JSON.parse(JSON.stringify(propsData)))
     const _doneProperties = ref<PropertyData>(JSON.parse(JSON.stringify(propsData)))
@@ -247,6 +248,7 @@ export const useVueTorrentStore = defineStore(
       useBinarySize,
       useBitSpeed,
       useIdForRssLinks,
+      hideColoredChip,
       _busyProperties,
       busyTorrentProperties,
       _doneProperties,
@@ -302,6 +304,7 @@ export const useVueTorrentStore = defineStore(
         refreshInterval.value = 2000
         fileContentInterval.value = 5000
         useIdForRssLinks.value = false
+        hideColoredChip.value = false
 
         _busyProperties.value = JSON.parse(JSON.stringify(propsData))
         _doneProperties.value = JSON.parse(JSON.stringify(propsData))


### PR DESCRIPTION
# feat(tags): option to have tags/categories without the “pill” shape (#1492)

- added an option to configure tags/categories without pill shape.
- can be achived thourgh enabling hide colered chips option in general settings.
![image](https://github.com/VueTorrent/VueTorrent/assets/106881717/14a3daf1-8c81-48d2-87a5-d930ee326ff1)
![image](https://github.com/VueTorrent/VueTorrent/assets/106881717/84b65c0f-d510-4339-aa2f-ed071822f0ee)
![image](https://github.com/VueTorrent/VueTorrent/assets/106881717/1c7cf648-e6fc-4440-a294-bb1ec8f4ee4d)
![image](https://github.com/VueTorrent/VueTorrent/assets/106881717/dc69b0c6-6a1b-4428-b5aa-4f4c2ab680c4)
![image](https://github.com/VueTorrent/VueTorrent/assets/106881717/1af89494-9b35-456d-9d53-41d2b8e41580)
https://youtu.be/42Y7L2RvH2g

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
