### PR TITLE
Fix: Do not wrap items to 2 or more lines in table view closes #1538

### DIFF
--- a/src/components/Dashboard/Views/Table/DashboardItems/ItemAmount.vue
+++ b/src/components/Dashboard/Views/Table/DashboardItems/ItemAmount.vue
@@ -5,7 +5,7 @@ defineProps<{ torrent: Torrent; value: (t: Torrent) => number; total?: (t: Torre
 </script>
 
 <template>
-  <td>
+  <td class="text-no-wrap">
     {{ value(torrent) }}
     <span v-if="total"> / {{ total(torrent) }} </span>
   </td>

--- a/src/components/Dashboard/Views/Table/DashboardItems/ItemData.vue
+++ b/src/components/Dashboard/Views/Table/DashboardItems/ItemData.vue
@@ -10,5 +10,5 @@ const { useBinarySize } = storeToRefs(useVueTorrentStore())
 </script>
 
 <template>
-  <td>{{ formatData(value(torrent), useBinarySize) }}</td>
+  <td class="text-no-wrap">{{ formatData(value(torrent), useBinarySize) }}</td>
 </template>

--- a/src/components/Dashboard/Views/Table/DashboardItems/ItemDateTime.vue
+++ b/src/components/Dashboard/Views/Table/DashboardItems/ItemDateTime.vue
@@ -12,8 +12,8 @@ const val = computed(() => props.value(props.torrent))
 </script>
 
 <template>
-  <td v-if="val > 0">
+  <td v-if="val > 0" class="text-no-wrap">
     {{ formatTimeSec(val, dateFormat) }}
   </td>
-  <td v-else>{{ $t('dashboard.not_complete') }}</td>
+  <td v-else class="text-no-wrap">{{ $t('dashboard.not_complete') }}</td>
 </template>

--- a/src/components/Dashboard/Views/Table/DashboardItems/ItemDuration.vue
+++ b/src/components/Dashboard/Views/Table/DashboardItems/ItemDuration.vue
@@ -27,8 +27,8 @@ const formattedDuration = computed(() => {
 </script>
 
 <template>
-  <td v-if="val > 0">
+  <td v-if="val > 0" class="text-no-wrap">
     {{ formattedDuration }}
   </td>
-  <td v-else>{{ $t('common.NA') }}</td>
+  <td v-else class="text-no-wrap">{{ $t('common.NA') }}</td>
 </template>

--- a/src/components/Dashboard/Views/Table/DashboardItems/ItemRelativeTime.vue
+++ b/src/components/Dashboard/Views/Table/DashboardItems/ItemRelativeTime.vue
@@ -6,5 +6,5 @@ defineProps<{ torrent: Torrent; value: (t: Torrent) => number }>()
 </script>
 
 <template>
-  <td>{{ dayjs(value(torrent) * 1000).fromNow() }}</td>
+  <td class="text-no-wrap">{{ dayjs(value(torrent) * 1000).fromNow() }}</td>
 </template>

--- a/src/components/Dashboard/Views/Table/DashboardItems/ItemSpeed.vue
+++ b/src/components/Dashboard/Views/Table/DashboardItems/ItemSpeed.vue
@@ -10,5 +10,5 @@ const { useBitSpeed } = storeToRefs(useVueTorrentStore())
 </script>
 
 <template>
-  <td>{{ formatSpeed(value(torrent), useBitSpeed) }}</td>
+  <td class="text-no-wrap">{{ formatSpeed(value(torrent), useBitSpeed) }}</td>
 </template>

--- a/src/components/Dashboard/Views/Table/DashboardItems/ItemText.vue
+++ b/src/components/Dashboard/Views/Table/DashboardItems/ItemText.vue
@@ -8,5 +8,5 @@ const val = computed(() => props.value(props.torrent))
 </script>
 
 <template>
-  <td :class="color ? color(val) : ''">{{ val }}</td>
+  <td :class="color ? color(val) : ''" class="text-no-wrap">{{ val }}</td>
 </template>


### PR DESCRIPTION
# Fix: Do not wrap items to 2 or more lines in table view closes #1538

in Table view the text items are wraping to 2 or more lines... more evident in low res screens.
![image](https://github.com/VueTorrent/VueTorrent/assets/106881717/882b7182-02f8-4dc0-96b7-e30ff7c125cd)

This PR fixes that by adding <nobr> tag to all the elememts in table view.

alternatives tried using white-space : nowrap but it did not work. i heard its decrypted

result:
![image](https://github.com/VueTorrent/VueTorrent/assets/106881717/4104d4cc-8136-4715-9572-61751fad38a4)

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
