### PR TITLE
fix(Dashboard): Fix span selection after #1740

### DIFF
--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -22,7 +22,7 @@ const { currentPage: dashboardPage, isSelectionMultiple, selectedTorrents, displ
 const dialogStore = useDialogStore()
 const maindataStore = useMaindataStore()
 const torrentStore = useTorrentStore()
-const { filteredAndSortedTorrents: torrents } = storeToRefs(torrentStore)
+const { processedTorrents: torrents } = storeToRefs(torrentStore)
 const vuetorrentStore = useVueTorrentStore()
 
 const isListView = computed(() => displayMode.value === DashboardDisplayMode.LIST)

--- a/src/stores/dashboard.ts
+++ b/src/stores/dashboard.ts
@@ -29,11 +29,11 @@ export const useDashboardStore = defineStore(
 
         return t('dashboard.selectedTorrentsCount', {
           count: selectedTorrents.value.length,
-          total: torrentStore.filteredTorrents.length,
+          total: torrentStore.processedTorrents.length,
           size: formatData(selectedSize, vuetorrentStore.useBinarySize)
         })
       } else {
-        return t('dashboard.torrentsCount', torrentStore.filteredTorrents.length)
+        return t('dashboard.torrentsCount', torrentStore.processedTorrents.length)
       }
     })
 
@@ -77,7 +77,7 @@ export const useDashboardStore = defineStore(
 
       const start = Math.min(endIndex, latestIndex)
       const end = Math.max(endIndex, latestIndex)
-      const hashes = torrentStore.filteredTorrents.slice(start, end + 1).map(t => t.hash)
+      const hashes = torrentStore.processedTorrents.slice(start, end + 1).map(t => t.hash)
       selectTorrents(...hashes)
     }
 
@@ -98,7 +98,7 @@ export const useDashboardStore = defineStore(
     })
 
     watch(
-      () => torrentStore.filteredTorrents,
+      () => torrentStore.processedTorrents,
       newValue => {
         const pageCount = Math.ceil(newValue.length / vuetorrentStore.paginationSize)
         if (pageCount < currentPage.value) {

--- a/src/stores/torrents.ts
+++ b/src/stores/torrents.ts
@@ -84,7 +84,7 @@ export const useTorrentStore = defineStore(
     }
 
     function getTorrentIndexByHash(hash: string) {
-      return filteredTorrents.value.findIndex(t => t.hash === hash)
+      return filteredAndSortedTorrents.value.findIndex(t => t.hash === hash)
     }
 
     async function deleteTorrents(hashes: string[], deleteWithFiles: boolean) {
@@ -145,9 +145,7 @@ export const useTorrentStore = defineStore(
       tagFilter,
       trackerFilter,
       sortCriterias,
-      torrentsWithFilters,
-      filteredTorrents,
-      filteredAndSortedTorrents,
+      processedTorrents: filteredAndSortedTorrents,
       setTorrentCategory,
       addTorrentTags,
       removeTorrentTags,


### PR DESCRIPTION
Span selection was still using the unsorted list of filtered torrents, renamed exposed symbol to prevent future omissions.