### PR TITLE
feat(Drag-and-Drop): Add instant download zone

### DIFF
--- a/src/components/Dialogs/AddTorrentDialog.vue
+++ b/src/components/Dialogs/AddTorrentDialog.vue
@@ -8,7 +8,6 @@ import { AddTorrentPayload } from '@/types/qbit/payloads'
 import { storeToRefs } from 'pinia'
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { toast } from 'vue3-toastify'
 
 const props = withDefaults(
   defineProps<{
@@ -70,24 +69,12 @@ function submit() {
     useDownloadPath: addTorrentParams.value.use_download_path
   }
 
-  toast
-    .promise(
-      torrentStore.addTorrents(files.value, urls.value, payload),
-      {
-        pending: t('toast.add.pending'),
-        error: t('toast.add.error', addTorrentStore.pendingTorrentsCount),
-        success: t('toast.add.success', addTorrentStore.pendingTorrentsCount)
-      },
-      {
-        autoClose: 1500
-      }
-    )
-    .then(() => {
-      cookieField.value?.saveValueToHistory()
-      addTorrentParamsForm.value?.saveFields()
-      addTorrentStore.resetForm()
-      close()
-    })
+  torrentStore.addTorrents(files.value, urls.value, payload).then(() => {
+    cookieField.value?.saveValueToHistory()
+    addTorrentParamsForm.value?.saveFields()
+    addTorrentStore.resetForm()
+    close()
+  })
 }
 
 function close() {
@@ -97,11 +84,11 @@ function close() {
 
 <template>
   <v-dialog
-    v-model="isOpened"
-    :class="$vuetify.display.mobile ? '' : 'w-75'"
-    :fullscreen="$vuetify.display.mobile"
-    scrollable
-    :transition="openSuddenly ? 'none' : 'dialog-bottom-transition'">
+      v-model="isOpened"
+      :class="$vuetify.display.mobile ? '' : 'w-75'"
+      :fullscreen="$vuetify.display.mobile"
+      scrollable
+      :transition="openSuddenly ? 'none' : 'dialog-bottom-transition'">
     <v-card>
       <v-card-title class="ios-margin">
         <v-toolbar color="transparent">
@@ -114,16 +101,16 @@ function close() {
         <v-row>
           <v-col cols="12">
             <v-file-input
-              v-model="files"
-              :label="t('dialogs.add.files')"
-              :show-size="vueTorrentStore.useBinarySize ? 1024 : 1000"
-              accept=".torrent"
-              counter
-              multiple
-              persistent-clear
-              persistent-hint
-              prepend-icon=""
-              variant="outlined">
+                v-model="files"
+                :label="t('dialogs.add.files')"
+                :show-size="vueTorrentStore.useBinarySize ? 1024 : 1000"
+                accept=".torrent"
+                counter
+                multiple
+                persistent-clear
+                persistent-hint
+                prepend-icon=""
+                variant="outlined">
               <template v-slot:prepend>
                 <v-icon color="accent">mdi-paperclip</v-icon>
               </template>
@@ -147,13 +134,13 @@ function close() {
 
             <v-slide-y-transition>
               <HistoryField
-                v-if="!!urls"
-                v-model="cookie"
-                :historyKey="HistoryKey.COOKIE"
-                ref="cookieField"
-                clearable
-                :label="$t('dialogs.add.cookie')"
-                :placeholder="$t('dialogs.add.cookie_placeholder')">
+                  v-if="!!urls"
+                  v-model="cookie"
+                  :historyKey="HistoryKey.COOKIE"
+                  ref="cookieField"
+                  clearable
+                  :label="$t('dialogs.add.cookie')"
+                  :placeholder="$t('dialogs.add.cookie_placeholder')">
                 <template v-slot:prepend>
                   <v-icon color="accent">mdi-cookie</v-icon>
                 </template>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -272,10 +272,11 @@
     "add": {
       "cookie": "Cookies",
       "cookie_placeholder": "name1=value1; name2=value2; ...",
-      "drop_label": "Drop torrent files and links here",
+      "drop_label": "Add torrent files and/or links to torrent queue",
       "file_overflow": "+{n} more",
       "files": "Select files",
       "first_last_piece_prio": "Prioritize first and last pieces",
+      "instant_drop_label": "Download instantly torrent files and/or links",
       "links": "Links (magnet, http, file, ...)",
       "params": {
         "add_to_top_of_queue": "Add to top of queue",

--- a/src/services/qbit/IProvider.ts
+++ b/src/services/qbit/IProvider.ts
@@ -289,7 +289,7 @@ export default interface IProvider {
    * @param urls Torrent URLs
    * @param params Torrent add parameters
    */
-  addTorrents(torrents: File[], urls: string, params: AddTorrentPayload): Promise<void>
+  addTorrents(torrents: File[], urls: string, params?: AddTorrentPayload): Promise<void>
 
   /**
    * Set the torrent file priority

--- a/src/services/qbit/MockProvider.ts
+++ b/src/services/qbit/MockProvider.ts
@@ -1310,7 +1310,7 @@ export default class MockProvider implements IProvider {
     })
   }
 
-  async addTorrents(_0: File[], _1: string, _2: AddTorrentPayload): Promise<void> {
+  async addTorrents(_0: File[], _1: string, _2?: AddTorrentPayload): Promise<void> {
     return this.generateResponse()
   }
 

--- a/src/services/qbit/QbitProvider.ts
+++ b/src/services/qbit/QbitProvider.ts
@@ -391,7 +391,7 @@ export default class QBitProvider implements IProvider {
       .then(res => res.data)
   }
 
-  async addTorrents(torrents: File[], urls: string, params: AddTorrentPayload): Promise<void> {
+  async addTorrents(torrents: File[], urls: string, params?: AddTorrentPayload): Promise<void> {
     let data
     if (torrents) {
       // torrent files
@@ -409,7 +409,7 @@ export default class QBitProvider implements IProvider {
       data = formData
     } else {
       // magnet links
-      data = new URLSearchParams(params as Parameters)
+      data = new URLSearchParams((params || {}) as Parameters)
     }
     !!urls && data.set('urls', urls)
     return this.axios.post('/torrents/add', data)

--- a/src/stores/torrents.ts
+++ b/src/stores/torrents.ts
@@ -7,10 +7,14 @@ import { Torrent } from '@/types/vuetorrent'
 import { useArrayFilter, useSorted } from '@vueuse/core'
 import { defineStore } from 'pinia'
 import { MaybeRefOrGetter, ref, toValue } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { toast } from 'vue3-toastify'
 
 export const useTorrentStore = defineStore(
   'torrents',
   () => {
+    const { t } = useI18n()
+
     const torrents = ref<Torrent[]>([])
 
     const isTextFilterActive = ref(true)
@@ -100,7 +104,19 @@ export const useTorrentStore = defineStore(
 
     async function addTorrents(torrents: File[], urls: string | string[], payload?: AddTorrentPayload) {
       const links = Array.isArray(urls) ? urls.join('\n') : urls
-      return await qbit.addTorrents(torrents, links, payload)
+      const torrentsCount = torrents.length + links.split('\n').filter(url => url.trim().length).length
+
+      return await toast.promise(
+          qbit.addTorrents(torrents, links, payload),
+          {
+            pending: t('toast.add.pending'),
+            error: t('toast.add.error', torrentsCount),
+            success: t('toast.add.success', torrentsCount)
+          },
+          {
+            autoClose: 1500
+          }
+        )
     }
 
     async function renameTorrent(hash: string, newName: string) {

--- a/src/stores/torrents.ts
+++ b/src/stores/torrents.ts
@@ -98,8 +98,9 @@ export const useTorrentStore = defineStore(
       }
     }
 
-    async function addTorrents(torrents: File[], urls: string, payload: AddTorrentPayload) {
-      return await qbit.addTorrents(torrents, urls, payload)
+    async function addTorrents(torrents: File[], urls: string | string[], payload?: AddTorrentPayload) {
+      const links = Array.isArray(urls) ? urls.join('\n') : urls
+      return await qbit.addTorrents(torrents, links, payload)
     }
 
     async function renameTorrent(hash: string, newName: string) {


### PR DESCRIPTION
Split DnDZone into 2 distinct fields:
- one for the same behavior "push to queue" at the top,
- and a new one to upload directly to qBittorrent (bottom)

## Demo

[Desktop 2024.06.24 - 23.32.26.01.webm](https://github.com/VueTorrent/VueTorrent/assets/22910497/68db9ed9-b5fa-4ad6-80f9-e0f59d3f252f)
