### PR TITLE
chore: Add mail contact for private requests

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Don't hesitate to create your PR in draft mode if you need some feedback
 VueTorrent welcomes localization contributions!
 
 We no longer accept PRs for translations as all locale data in this repo is there only for reference and building from source.
-Instead head to our [Discord server](https://discord.gg/KDQP7fR467) to get your invitation link to the [Tolgee](https://tolgee.io) project.
+Instead head to the [issue creation page](https://github.com/VueTorrent/VueTorrent/issues/new/choose) to contact us and get your invitation link to the [Tolgee](https://tolgee.io) project.
 
 ## Wiki changes
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://discord.gg/KDQP7fR467
     about: Join the discord server to contact us directly
   - name: Email
-    url: mailto:vuetorrent@larsluph.dev?cc=dw.daanwijns@gmail.com
+    url: mailto:vuetorrent@larsluph.dev
     about: Or sent us a mail for private requests

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,7 @@ blank_issues_enabled: true
 contact_links:
   - name: Discord
     url: https://discord.gg/KDQP7fR467
-    about: 'Join the discord server to contact us directly'
+    about: Join the discord server to contact us directly
+  - name: Email
+    url: mailto:vuetorrent@larsluph.dev?cc=dw.daanwijns@gmail.com
+    about: Or sent us a mail for private requests

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The sleekest looking WebUI for qBittorrent made with Vue.js!
 
 ## Demo
 
-A live demo **with mocked data** is available here: https://vuetorrent.github.io/demo
+A live demo **with mocked data** is available here: <https://vuetorrent.github.io/demo>
 
 > [!NOTE] This version isn't connected to a qBittorrent instance.
 >
@@ -57,8 +57,7 @@ Checkout the [wiki](https://github.com/VueTorrent/VueTorrent/wiki/Installation)!
 - `npm run lint` (to format the code)
 - `docker-compose up -d` (starts a qbittorrent docker, optional)
 - Open the WebUI on localhost with the default credentials
-  - Default username is always `admin`
-  - Default password is `adminadmin` **on 4.6.0 and below**, and is generated in logs on 4.6.1 and above
+  - See #1720 for more details
 - Make sure "CSRF protection" and "Host header verification" is disabled in the qBittorrent preferences
 - Edit `env.development` to tweak your dev environment (e.g. mocked data)
 


### PR DESCRIPTION
Add mail option to issue creation page for private requests and users without Discord accounts (either due to geo bans or for personal reasons)