### PR TITLE
chore: Move mailto link not working

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -39,7 +39,7 @@ Don't hesitate to create your PR in draft mode if you need some feedback
 VueTorrent welcomes localization contributions!
 
 We no longer accept PRs for translations as all locale data in this repo is there only for reference and building from source.
-Instead head to the [issue creation page](https://github.com/VueTorrent/VueTorrent/issues/new/choose) to contact us and get your invitation link to the [Tolgee](https://tolgee.io) project.
+Instead head to our [Discord server](https://discord.gg/KDQP7fR467) or contact us directly [by mail](mailto:vuetorrent@larsluph.dev) to get your invitation link to the [Tolgee](https://tolgee.io) project.
 
 ## Wiki changes
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: Discord
     url: https://discord.gg/KDQP7fR467
     about: Join the discord server to contact us directly
-  - name: Email
-    url: mailto:vuetorrent@larsluph.dev
-    about: Or sent us a mail for private requests


### PR DESCRIPTION
Mailto link doesn't work in issue templates. I suppose it's because of a non-HTTP(s) protocol.