### PR TITLE
chore: Remove sass deprecation warnings

### DIFF
--- a/src/components/DnDZone.vue
+++ b/src/components/DnDZone.vue
@@ -99,11 +99,11 @@ onUnmounted(() => {
 
 <style lang="scss" scoped>
 .dnd-bg {
+  background-color: #000000a8;
+
   &-active {
     background-color: #404040a8;
   }
-
-  background-color: #000000a8;
 }
 
 .dnd-zone-border {


### PR DESCRIPTION
**Deprecation Warning**: Sass's behavior for declarations that appear after nested rules will be changing to match the behavior specified by CSS in an upcoming version. To keep the existing behavior, move the declaration above the nested rule. To opt into the new behavior, wrap the declaration in `& {}`.

More info: https://sass-lang.com/d/mixed-decls