### PR TITLE
chore(content): Swap order of invert priority calls to prevent file checking

### DIFF
--- a/src/stores/content.ts
+++ b/src/stores/content.ts
@@ -132,8 +132,8 @@ export const useContentStore = defineStore('content', () => {
     const unwantedFileIds = files.filter(file => file.priority === FilePriority.DO_NOT_DOWNLOAD).map(file => file.index)
 
     await Promise.all([
-      setFilePriority(selectedFileIds, FilePriority.DO_NOT_DOWNLOAD),
-      setFilePriority(unwantedFileIds, FilePriority.NORMAL)
+      setFilePriority(unwantedFileIds, FilePriority.NORMAL),
+      setFilePriority(selectedFileIds, FilePriority.DO_NOT_DOWNLOAD)
     ])
   }
 


### PR DESCRIPTION
When using the "Recheck torrents on completion settings" and unchecking all files in a torrent, progress is considered 100% and a recheck event is fired.

To prevent this behaviour, we first select unwanted files before unselecting wanted files to always have at least one file checked in the process.

NB: Not sure if we should include it in the changelog, thus `chore`