### PR TITLE
perf(App): Display loading toast when fetching login status

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,8 +9,10 @@ import { backend } from '@/services/backend'
 import { useAddTorrentStore, useAppStore, useDialogStore, useLogStore, useMaindataStore, usePreferenceStore, useTorrentStore, useVueTorrentStore } from '@/stores'
 import { storeToRefs } from 'pinia'
 import { onBeforeMount, watch, watchEffect } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { toast } from 'vue3-toastify'
 
+const { t } = useI18n()
 const addTorrentStore = useAddTorrentStore()
 const appStore = useAppStore()
 const dialogStore = useDialogStore()
@@ -23,11 +25,9 @@ const vuetorrentStore = useVueTorrentStore()
 const { language, uiTitleCustom, uiTitleType, useBitSpeed } = storeToRefs(vuetorrentStore)
 
 const checkAuthentication = async () => {
-  await toast.promise(appStore.fetchAuthStatus(), {
-    pending: 'Checking current auth status...'
-  }, {
-    delay: 1  // FIXME: Only display toast after a second without resolve
-  })
+  const promise = appStore.fetchAuthStatus()
+  const timer = setTimeout(() => toast.promise(promise, { pending: t('login.pending')}), 1000)
+  promise.then(() => clearTimeout(timer))
 }
 
 const blockContextMenu = () => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,6 +9,7 @@ import { backend } from '@/services/backend'
 import { useAddTorrentStore, useAppStore, useDialogStore, useLogStore, useMaindataStore, usePreferenceStore, useTorrentStore, useVueTorrentStore } from '@/stores'
 import { storeToRefs } from 'pinia'
 import { onBeforeMount, watch, watchEffect } from 'vue'
+import { toast } from 'vue3-toastify'
 
 const addTorrentStore = useAddTorrentStore()
 const appStore = useAppStore()
@@ -22,7 +23,11 @@ const vuetorrentStore = useVueTorrentStore()
 const { language, uiTitleCustom, uiTitleType, useBitSpeed } = storeToRefs(vuetorrentStore)
 
 const checkAuthentication = async () => {
-  await appStore.fetchAuthStatus()
+  await toast.promise(appStore.fetchAuthStatus(), {
+    pending: 'Checking current auth status...'
+  }, {
+    delay: 1  // FIXME: Only display toast after a second without resolve
+  })
 }
 
 const blockContextMenu = () => {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -474,6 +474,7 @@
   "login": {
     "error": "Login failed!",
     "password": "Password",
+    "pending": "Checking current auth status...",
     "rules": {
       "password_required": "Password is required",
       "username_required": "Username is required"

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -8,7 +8,9 @@ export const useAppStore = defineStore('app', () => {
 
   async function fetchAuthStatus() {
     const ver: string | false = await qbit.getVersion().catch(() => false)
-    await setAuthStatus(ver !== false, ver || undefined)
+    const auth_status = ver !== false
+    await setAuthStatus(auth_status, ver || undefined)
+    return auth_status
   }
 
   async function setAuthStatus(val: boolean, ver?: string) {


### PR DESCRIPTION
Displays a pending toast when fetch time exceeds 1 sec, to prevent users from trying to login if they already are (bypass or old session still valid)