### PR TITLE
chore(readme): Update dev env setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Checkout the [wiki](https://github.com/VueTorrent/VueTorrent/wiki/Installation)!
 - `docker-compose up -d` (starts a qbittorrent docker, optional)
 - Open the WebUI on localhost with the default credentials
   - See #1720 for more details
-- Make sure "CSRF protection" and "Host header verification" is disabled in the qBittorrent preferences
+- Make sure WebUI > "Host header validation" is disabled in the qBittorrent preferences
 - Edit `env.development` to tweak your dev environment (e.g. mocked data)
 
 ## Features

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -50,7 +50,6 @@ export default defineConfig(({ mode }) => {
       port: 3000,
       proxy: {
         '/api': {
-          changeOrigin: true,
           secure: false,
           target: `${proxyTarget}:${qBittorrentPort}`
         }


### PR DESCRIPTION
CSRF protection isn't interfering with the vite proxy, only Host header validation because of the port redirection.