### PR TITLE
feat: Highlighting and peeking torrent

### DIFF
--- a/src/components/Dashboard/Views/Grid/GridTorrent.vue
+++ b/src/components/Dashboard/Views/Grid/GridTorrent.vue
@@ -71,12 +71,7 @@ function getTorrentColor(torrent: Torrent) {
 </script>
 
 <template>
-  <v-card
-    class="cursor-pointer"
-    :style="`border-left: 6px solid ${stateColor}`"
-    height="100%"
-    :color="getTorrentColor(torrent)"
-    @click="$emit('onTorrentClick', $event, torrent)">
+  <v-card class="cursor-pointer" :style="`border-left: 6px solid ${stateColor}`" height="100%" :color="getTorrentColor(torrent)" @click="$emit('onTorrentClick', $event, torrent)">
     <v-card-title class="text-wrap text-subtitle-1 pt-1 pb-0">{{ torrent.name }}</v-card-title>
     <v-card-text>
       <div class="d-flex flex-gap flex-wrap">

--- a/src/components/Dashboard/Views/Grid/GridTorrent.vue
+++ b/src/components/Dashboard/Views/Grid/GridTorrent.vue
@@ -59,6 +59,15 @@ const getComponent = (type: DashboardPropertyType) => {
 
 const isTorrentSelected = computed(() => dashboardStore.isTorrentInSelection(props.torrent.hash))
 const stateColor = computed(() => current.value.colors[getTorrentStateColor(props.torrent.state)])
+
+function getTorrentColor(torrent: Torrent) {
+  if (isTorrentSelected.value) return `${getTorrentStateColor(torrent.state)}-darken-3`
+  if (dashboardStore.isSelectionMultiple) return undefined
+  if (dashboardStore.isTorrentHighlighted(torrent.hash)) {
+    return `${getTorrentStateColor(torrent.state)}-lighten-3`
+  }
+  return undefined
+}
 </script>
 
 <template>
@@ -66,7 +75,7 @@ const stateColor = computed(() => current.value.colors[getTorrentStateColor(prop
     class="cursor-pointer"
     :style="`border-left: 6px solid ${stateColor}`"
     height="100%"
-    :color="isTorrentSelected ? `${getTorrentStateColor(torrent.state)}-darken-3` : undefined"
+    :color="getTorrentColor(torrent)"
     @click="$emit('onTorrentClick', $event, torrent)">
     <v-card-title class="text-wrap text-subtitle-1 pt-1 pb-0">{{ torrent.name }}</v-card-title>
     <v-card-text>

--- a/src/components/Dashboard/Views/List/ListTorrent.vue
+++ b/src/components/Dashboard/Views/List/ListTorrent.vue
@@ -57,6 +57,15 @@ const getComponent = (type: DashboardPropertyType) => {
 }
 const isTorrentSelected = computed(() => dashboardStore.isTorrentInSelection(props.torrent.hash))
 const stateColor = computed(() => current.value.colors[getTorrentStateColor(props.torrent.state)])
+
+function getTorrentColor(torrent: Torrent) {
+  if (isTorrentSelected.value) return `${getTorrentStateColor(torrent.state)}-darken-3`
+  if (dashboardStore.isSelectionMultiple) return undefined
+  if (dashboardStore.isTorrentHighlighted(torrent.hash)) {
+    return `${getTorrentStateColor(torrent.state)}-lighten-3`
+  }
+  return undefined
+}
 </script>
 
 <template>
@@ -64,7 +73,7 @@ const stateColor = computed(() => current.value.colors[getTorrentStateColor(prop
     class="cursor-pointer"
     :style="`border-left: 6px solid ${stateColor}`"
     width="100%"
-    :color="isTorrentSelected ? `${getTorrentStateColor(torrent.state)}-darken-3` : undefined"
+    :color="getTorrentColor(torrent)"
     @click="$emit('onTorrentClick', $event, torrent)">
     <v-card-title class="text-wrap pt-1 pb-0 px-2 text-truncate" style="font-size: 0.97em">{{ torrent.name }}</v-card-title>
     <v-card-text class="pa-2 pt-0">

--- a/src/components/Dashboard/Views/List/ListTorrent.vue
+++ b/src/components/Dashboard/Views/List/ListTorrent.vue
@@ -69,12 +69,7 @@ function getTorrentColor(torrent: Torrent) {
 </script>
 
 <template>
-  <v-card
-    class="cursor-pointer"
-    :style="`border-left: 6px solid ${stateColor}`"
-    width="100%"
-    :color="getTorrentColor(torrent)"
-    @click="$emit('onTorrentClick', $event, torrent)">
+  <v-card class="cursor-pointer" :style="`border-left: 6px solid ${stateColor}`" width="100%" :color="getTorrentColor(torrent)" @click="$emit('onTorrentClick', $event, torrent)">
     <v-card-title class="text-wrap pt-1 pb-0 px-2 text-truncate" style="font-size: 0.97em">{{ torrent.name }}</v-card-title>
     <v-card-text class="pa-2 pt-0">
       <div class="d-flex flex-gap flex-wrap">

--- a/src/components/Dashboard/Views/Table/TableView.vue
+++ b/src/components/Dashboard/Views/Table/TableView.vue
@@ -40,7 +40,12 @@ function isTorrentSelected(torrent: TorrentType) {
   return dashboardStore.isTorrentInSelection(torrent.hash)
 }
 
-const getTorrentRowColorClass = (torrent: TorrentType) => [isTorrentSelected(torrent) ? `bg-${getTorrentStateColor(torrent.state)}-darken-3` : '']
+function getTorrentRowColorClass(torrent: TorrentType) {
+  if (isTorrentSelected(torrent)) return `bg-${getTorrentStateColor(torrent.state)}-darken-3`
+  if (!dashboardStore.isSelectionMultiple && dashboardStore.isTorrentHighlighted(torrent.hash)) {
+    return `bg-${getTorrentStateColor(torrent.state)}-lighten-3`
+  }
+}
 </script>
 
 <template>

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -74,6 +74,8 @@ function onTorrentClick(e: { shiftKey: boolean; metaKey: boolean; ctrlKey: boole
   } else if (doesCommand(e) || dashboardStore.isSelectionMultiple) {
     dashboardStore.isSelectionMultiple = true
     dashboardStore.toggleSelect(torrent.hash)
+  } else {
+    dashboardStore.setHighlightedTorrent(torrent.hash)
   }
 }
 

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -36,12 +36,9 @@ const rightClickProperties = reactive<RightClickProperties>({
 
 const singleClickTimeoutId = ref<NodeJS.Timeout>()
 const shouldPeekTorrent = ref(!!highlightedTorrent.value)
-watch(
-  highlightedTorrent,
-  newValue => {
-    shouldPeekTorrent.value = !!newValue
-  }
-)
+watch(highlightedTorrent, newValue => {
+  shouldPeekTorrent.value = !!newValue
+})
 watch(
   shouldPeekTorrent,
   shouldPeekTorrentNow => {
@@ -288,11 +285,7 @@ onBeforeUnmount(() => {
   <TRC :right-click-properties="rightClickProperties" />
   <v-bottom-sheet v-model="shouldPeekTorrent">
     <v-sheet>
-      <TorrentDetail
-        v-if="highlightedTorrent"
-        :is-peeking="true"
-        @onClose="handleClosingTorrentDetail"
-      />
+      <TorrentDetail v-if="highlightedTorrent" :is-peeking="true" @onClose="handleClosingTorrentDetail" />
     </v-sheet>
   </v-bottom-sheet>
 </template>

--- a/src/pages/TorrentDetail.vue
+++ b/src/pages/TorrentDetail.vue
@@ -43,10 +43,7 @@ const tabs = [
 
 const tab = ref('overview')
 
-const hash = computed(() => props.isPeeking
-  ? dashboardStore.highlightedTorrent as string
-  : router.currentRoute.value.params.hash as string
-)
+const hash = computed(() => (props.isPeeking ? (dashboardStore.highlightedTorrent as string) : (router.currentRoute.value.params.hash as string)))
 const torrent = computed(() => torrentStore.getTorrentByHash(hash.value))
 
 const goHome = () => {

--- a/src/stores/dashboard.ts
+++ b/src/stores/dashboard.ts
@@ -15,6 +15,7 @@ export const useDashboardStore = defineStore(
     const selectedTorrents = ref<string[]>([])
     const latestSelectedTorrent = ref<string>()
     const displayMode = ref(DashboardDisplayMode.LIST)
+    const highlightedTorrent = ref<string>()
 
     const { t } = useI18n()
     const torrentStore = useTorrentStore()
@@ -95,6 +96,14 @@ export const useDashboardStore = defineStore(
       selectedTorrents.value = []
     }
 
+    function setHighlightedTorrent(hash: string) {
+      highlightedTorrent.value = hash
+    }
+
+    function isTorrentHighlighted(hash: string) {
+      return highlightedTorrent.value === hash
+    }
+
     watch(selectedTorrents, newValue => {
       if (newValue.length === 0) {
         latestSelectedTorrent.value = undefined
@@ -127,6 +136,9 @@ export const useDashboardStore = defineStore(
       spanTorrentSelection,
       selectAllTorrents,
       unselectAllTorrents,
+      setHighlightedTorrent,
+      isTorrentHighlighted,
+      highlightedTorrent,
       toggleSelect,
       $reset: () => {
         _page.value = 1
@@ -134,6 +146,7 @@ export const useDashboardStore = defineStore(
         selectedTorrents.value = []
         latestSelectedTorrent.value = undefined
         displayMode.value = DashboardDisplayMode.LIST
+        highlightedTorrent.value = undefined
       }
     }
   },


### PR DESCRIPTION
# Highlight torrent and display details
In this PR I tried to mimic the info panel of the original WebUI. Currently, left clicking on torrent does nothing, just quickly flashes the clicked torrent. So I want to try out an idea of peeking torrent details without having to navigated to another page. In other to do that I introduced these changes:

## Highlighting torrent
In Dashboard view, user can highlight a single torrent by left clicking on it. This is done in when the select mode is OFF.
The torrent hash is kept in the `dashboard` store's `highlightedTorrent`. In the dashboard, it would have the color corresponded to its state, with the variant "-lighten-3". Torrents can be highlighted in all views (Table, List & Grid).

## Refactoring of `TorrentDetail.vue`
`TorrentDetail` now has the optional prop `isPeeking` (false by default).

Normally, double clicking on torrent will redirect user to the detail route and display `TorrentDetail` as a full page. The torrent hash and the active tab is retrieved from the route. Changing tabs modified the route as usual.

Now when torrent is highlighted, Dashboard.vue renders `TorrentDetail` inside a bottom sheet, passing `isPeeking` true to this component. The torrent hash is retrieved from `dashboard` store's `highlightedTorrent`. TorrentDetail keeps the active tab internally. Changing tabs won't change route.

Clicking outside of the bottom sheet simply closes it.

### Some screenshots
<img width="1673" alt="peeking01" src="https://github.com/user-attachments/assets/462d3f37-bf93-451d-b54b-1610960a6c3c">
<img width="1673" alt="peeking02" src="https://github.com/user-attachments/assets/11b10fba-96bf-48aa-9650-cfc361fc20b6">
<img width="1673" alt="peeking03" src="https://github.com/user-attachments/assets/dc1be53e-bdad-4d05-91bc-e04e80e6ed3c">


## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
