### PR TITLE
feat: responsive search bar placement

### DIFF
--- a/src/components/Dashboard/Toolbar.vue
+++ b/src/components/Dashboard/Toolbar.vue
@@ -3,10 +3,10 @@ import { DashboardDisplayMode, PaginationPosition } from '@/constants/vuetorrent
 import { comparators } from '@/helpers'
 import { useDashboardStore, useNavbarStore, useTorrentStore, useVueTorrentStore } from '@/stores'
 import { Torrent } from '@/types/vuetorrent'
-import debounce from 'lodash.debounce'
 import { storeToRefs } from 'pinia'
 import { computed, mergeProps } from 'vue'
 import { useI18n } from 'vue-i18n'
+import TorrentSearchbar from '@/components/TorrentSearchbar.vue'
 
 const { t } = useI18n()
 
@@ -80,17 +80,6 @@ const sortOption = computed({
 
 const isPaginationTop = computed(() => !!(paginationPosition.value & PaginationPosition.TOP))
 
-function resetInput() {
-  torrentStore.textFilter = ''
-}
-
-const torrentTitleFilter = computed({
-  get: () => torrentStore.textFilter,
-  set: debounce((newValue: string | null) => {
-    torrentStore.textFilter = newValue ?? ''
-  }, 300)
-})
-
 function toggleSelectMode() {
   if (isSelectionMultiple.value) {
     dashboardStore.unselectAllTorrents()
@@ -100,21 +89,8 @@ function toggleSelectMode() {
 </script>
 
 <template>
-  <div>
-    <v-text-field
-      id="searchInput"
-      v-model="torrentTitleFilter"
-      :label="t('dashboard.searchInputLabel')"
-      clearable
-      density="compact"
-      single-line
-      hide-details
-      prepend-inner-icon="mdi-magnify"
-      variant="solo"
-      @click:clear="resetInput()" />
-  </div>
-
-  <div class="d-flex my-3">
+  <TorrentSearchbar v-if="$vuetify.display.mdAndDown" class="my-2"/>
+  <div class="d-flex mb-2 align-center">
     <v-tooltip :text="t('dashboard.toggleSelectMode')" location="top">
       <template v-slot:activator="{ props }">
         <v-btn :icon="isSelectionMultiple ? 'mdi-checkbox-marked' : 'mdi-checkbox-blank-outline'" v-bind="props" variant="plain" @click="toggleSelectMode" />
@@ -143,7 +119,7 @@ function toggleSelectMode() {
         <v-btn :icon="sortOption.reverse ? 'mdi-sort-descending' : 'mdi-sort-ascending'" v-bind="props" variant="plain" @click="sortOption.reverse = !sortOption.reverse" />
       </template>
     </v-tooltip>
-    <div class="d-flex align-center pa-0">
+    <div class="d-flex align-center pl-2">
       <v-select
         v-model="sortOption.value"
         :items="torrentSortOptions"

--- a/src/components/Navbar/Navbar.vue
+++ b/src/components/Navbar/Navbar.vue
@@ -10,6 +10,7 @@ import SpeedGraph from './SideWidgets/SpeedGraph.vue'
 import TransferStats from './SideWidgets/TransferStats.vue'
 import ActiveFilters from './TopWidgets/ActiveFilters.vue'
 import TopContainer from './TopWidgets/TopContainer.vue'
+import TorrentSearchbar from '@/components/TorrentSearchbar.vue'
 
 const router = useRouter()
 const dashboardStore = useDashboardStore()
@@ -65,14 +66,14 @@ const goHome = () => {
 
   <v-app-bar class="ios-padding">
     <v-app-bar-nav-icon @click="toggleDrawer" />
-    <v-app-bar-title class="title">
       <div class="title-wrapper cursor-pointer" @click="goHome">
         <span v-if="$vuetify.display.smAndUp" class="text-accent">Vue</span>
         <span v-if="$vuetify.display.smAndUp">Torrent</span>
       </div>
 
-      <ActiveFilters />
-    </v-app-bar-title>
+    <ActiveFilters />
+    <TorrentSearchbar v-if="$vuetify.display.lgAndUp" bg-color="#121212" class="px-6" />
+    <v-spacer v-else />
 
     <TopContainer />
   </v-app-bar>
@@ -83,12 +84,11 @@ const goHome = () => {
   padding-inline-start: 0 !important;
   padding-inline-end: 0 !important;
 }
-.title {
-  margin-inline-start: calc(16px - 0.4em);
-}
 .title-wrapper {
   display: inline-flex;
   width: min-content;
   padding: 0.4em;
+  align-items: center;
+  font-size: larger;
 }
 </style>

--- a/src/components/Navbar/Navbar.vue
+++ b/src/components/Navbar/Navbar.vue
@@ -72,6 +72,7 @@ const goHome = () => {
       </div>
 
     <ActiveFilters />
+
     <TorrentSearchbar v-if="$vuetify.display.lgAndUp" bg-color="#121212" class="px-6" />
     <v-spacer v-else />
 

--- a/src/components/TorrentSearchbar.vue
+++ b/src/components/TorrentSearchbar.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+
+import { computed } from 'vue'
+import debounce from 'lodash.debounce'
+import { useTorrentStore } from '@/stores'
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+const torrentStore = useTorrentStore()
+
+function resetInput() {
+  torrentStore.textFilter = ''
+}
+
+const torrentTitleFilter = computed({
+  get: () => torrentStore.textFilter,
+  set: debounce((newValue: string | null) => {
+    torrentStore.textFilter = newValue ?? ''
+  }, 300)
+})
+</script>
+
+<template>
+    <v-text-field
+      id="searchInput"
+      v-model="torrentTitleFilter"
+      :label="t('dashboard.searchInputLabel')"
+      clearable
+      density="compact"
+      single-line
+      hide-details
+      prepend-inner-icon="mdi-magnify"
+      variant="solo"
+      base-color="white"
+      @click:clear="resetInput()" />
+</template>
+
+<style scoped>
+</style>

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -192,7 +192,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div class="pt-4 px-1 px-sm-5">
+  <div class="pt-2 px-1 px-sm-4">
     <Toolbar />
 
     <v-row class="ma-0 pa-0">


### PR DESCRIPTION
# feat: responsive search bar placement

This PR implements a responsive search bar placement at the breakpoint of 1280px.
Above this breakpoint the search bar will be placed in the Navbar,
under this breakpoint the search bar will remain at it's current place.
With this change, each view type for the torrents will have more space, to display more torrents on desktop envs.

For this change the search bar got refactored into a Vue component called `TorrentSearchbar`.
Please check if the file for the component is in a folder to your liking.

Furthermore, some margins and paddings got changed to fix too small or too large gaps
and some elements got centered vertically to their parent component.
If any of the paddings or margins are not to your liking, please say so.

![image](https://github.com/user-attachments/assets/52104643-8cb4-4d6b-a9f0-dc8bae51d72a)
![image](https://github.com/user-attachments/assets/4212640d-8293-4bb2-a679-318bc62317ef)

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
