### PR TITLE
fix: Increase menu overflow threshold

### DIFF
--- a/src/components/Navbar/TopWidgets/TopContainer.vue
+++ b/src/components/Navbar/TopWidgets/TopContainer.vue
@@ -62,7 +62,7 @@ function openSettings() {
   <v-divider inset vertical />
 
   <TopOverflow
-    v-if="$vuetify.display.mobile"
+    v-if="$vuetify.display.smAndDown"
     @deleteTorrents="deleteTorrents"
     @openLogs="openLogs"
     @openSearchEngine="openSearchEngine"


### PR DESCRIPTION
Prevent active filter chip from overflowing (and being hidden) into the menu

Before:
![image](https://github.com/user-attachments/assets/8ae38796-c960-4e40-8eac-f48d5408271f)

After:
![image](https://github.com/user-attachments/assets/84f38285-8bc6-441b-87c4-825a381f4498)
