### PR TITLE
feat: tooltip on torrent state indicator for table view

### DIFF
--- a/src/components/Dashboard/Views/Table/TableView.vue
+++ b/src/components/Dashboard/Views/Table/TableView.vue
@@ -2,7 +2,7 @@
 import Header from './Header.vue'
 import TableTorrent from './TableTorrent.vue'
 import { TorrentState } from '@/constants/vuetorrent'
-import { comparators, getTorrentStateColor } from '@/helpers'
+import { comparators, getTorrentStateColor, getTorrentStateValue } from '@/helpers'
 import { useDashboardStore, useTorrentStore, useVueTorrentStore } from '@/stores'
 import { Torrent, Torrent as TorrentType } from '@/types/vuetorrent'
 import { storeToRefs } from 'pinia'
@@ -65,7 +65,17 @@ const getTorrentRowColorClass = (torrent: TorrentType) => [isTorrentSelected(tor
         @touchstart="$emit('startPress', $event.touches.item(0)!, torrent)"
         @click="$emit('onTorrentClick', $event, torrent)"
         @dblclick="$emit('onTorrentDblClick', torrent)">
-        <td :class="`pa-0 bg-torrent-${TorrentState[torrent.state].toLowerCase()}`" />
+
+        <v-tooltip top>
+          <template v-slot:activator="{ props }">
+            <td
+              v-bind="props"
+              :class="`pa-0 bg-torrent-${TorrentState[torrent.state].toLowerCase()}`"
+            />
+          </template>
+          {{$t(`torrent.state.${getTorrentStateValue(torrent.state)}`)}}
+        </v-tooltip>
+
         <td v-if="dashboardStore.isSelectionMultiple">
           <v-checkbox-btn
             :model-value="isTorrentSelected(torrent)"


### PR DESCRIPTION
# feat: tooltip on torrent state indicator for table view

This PR implements a tooltip for the left torrent state indicator at the beginning of a line on the table view.
With this change the user is able to get information of a torrent's state without having the `State` column enabled,
saving valuable screen space and eventually preventing the torrent names from wrapping.

![image](https://github.com/user-attachments/assets/c0df310c-98e9-4fd3-b55c-b250104191e9)

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
