### PR TITLE
fix: TorrentSearchbar color

### DIFF
--- a/src/components/Navbar/Navbar.vue
+++ b/src/components/Navbar/Navbar.vue
@@ -73,7 +73,7 @@ const goHome = () => {
 
     <ActiveFilters />
 
-    <TorrentSearchbar v-if="$vuetify.display.lgAndUp" bg-color="#121212" class="px-6" />
+    <TorrentSearchbar v-if="$vuetify.display.lgAndUp" bg-color="background" class="px-6" />
     <v-spacer v-else />
 
     <TopContainer />


### PR DESCRIPTION
# fix: TorrentSearchbar color

After merging #1883 the TorrentSearchbar now also has the dark mode color in light mode when placed in the Navbar.
This PR fixes the coloring issue for all themes (light/dark legacy/redesigned mode)

Old:
![image](https://github.com/user-attachments/assets/6a49470d-d250-41c6-b7e7-6f722626d789)
New/fixed:
![image](https://github.com/user-attachments/assets/23d37cfa-6d8f-4458-ace5-c13e69a870e0)


## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
