### PR TITLE
feat(V5): Add new settings

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -94,6 +94,9 @@ watch(
 )
 
 watchEffect(() => {
+  const appInstanceName = preferencesStore.preferences!.app_instance_name
+  const baseName = appInstanceName ?? 'VueTorrent'
+
   const mode = uiTitleType.value
   switch (mode) {
     case TitleOptions.GLOBAL_SPEED:
@@ -101,7 +104,7 @@ watchEffect(() => {
         '[' +
         `D: ${formatSpeed(serverState.value?.dl_info_speed ?? 0, useBitSpeed.value)}, ` +
         `U: ${formatSpeed(serverState.value?.up_info_speed ?? 0, useBitSpeed.value)}` +
-        '] VueTorrent'
+        `] ${baseName}`
       break
     case TitleOptions.FIRST_TORRENT_STATUS:
       const torrent = torrents.value.at(0)
@@ -111,9 +114,9 @@ watchEffect(() => {
           `D: ${formatSpeed(torrent.dlspeed, useBitSpeed.value)}, ` +
           `U: ${formatSpeed(torrent.upspeed, useBitSpeed.value)}, ` +
           `${formatPercent(torrent.progress)}` +
-          '] VueTorrent'
+          `] ${baseName}`
       } else {
-        document.title = '[N/A] VueTorrent'
+        document.title = `[N/A] ${baseName}`
       }
       break
     case TitleOptions.CUSTOM:

--- a/src/App.vue
+++ b/src/App.vue
@@ -94,8 +94,8 @@ watch(
 )
 
 watchEffect(() => {
-  const appInstanceName = preferencesStore.preferences!.app_instance_name
-  const baseName = appInstanceName ?? 'VueTorrent'
+  const appInstanceName = preferencesStore.preferences?.app_instance_name
+  const baseName = (appInstanceName && appInstanceName.length) ? appInstanceName : 'VueTorrent'
 
   const mode = uiTitleType.value
   switch (mode) {
@@ -124,7 +124,7 @@ watchEffect(() => {
       break
     case TitleOptions.DEFAULT:
     default:
-      document.title = 'VueTorrent'
+      document.title = baseName
       break
   }
 })

--- a/src/App.vue
+++ b/src/App.vue
@@ -95,7 +95,7 @@ watch(
 
 watchEffect(() => {
   const appInstanceName = preferencesStore.preferences?.app_instance_name
-  const baseName = (appInstanceName && appInstanceName.length) ? appInstanceName : 'VueTorrent'
+  const baseName = appInstanceName && appInstanceName.length ? appInstanceName : 'VueTorrent'
 
   const mode = uiTitleType.value
   switch (mode) {

--- a/src/components/Dashboard/RightClick.vue
+++ b/src/components/Dashboard/RightClick.vue
@@ -7,15 +7,7 @@ import RenameTorrentDialog from '@/components/Dialogs/RenameTorrentDialog.vue'
 import ShareLimitDialog from '@/components/Dialogs/ShareLimitDialog.vue'
 import SpeedLimitDialog from '@/components/Dialogs/SpeedLimitDialog.vue'
 import TagFormDialog from '@/components/Dialogs/TagFormDialog.vue'
-import {
-  useCategoryStore,
-  useDashboardStore,
-  useDialogStore,
-  useMaindataStore,
-  usePreferenceStore,
-  useTagStore,
-  useTorrentStore
-} from '@/stores'
+import { useCategoryStore, useDashboardStore, useDialogStore, useMaindataStore, usePreferenceStore, useTagStore, useTorrentStore } from '@/stores'
 import { RightClickMenuEntryType } from '@/types/vuetorrent'
 import { BlobReader, BlobWriter, ZipWriter } from '@zip.js/zip.js'
 import { computed } from 'vue'
@@ -154,13 +146,13 @@ async function exportTorrents() {
   if (ts.length === 1) {
     const t = ts[0]!
     const blob = await torrentStore.exportTorrent(t.hash)
-    downloadFile(`${ t.name }.torrent`, blob)
+    downloadFile(`${t.name}.torrent`, blob)
     return
   }
 
   const zipWriter = new ZipWriter(new BlobWriter('application/zip'), { bufferedWrite: true })
   await Promise.all(
-    hashes.value.map(hash => torrentStore.exportTorrent(hash).then(blob => zipWriter.add(`${ torrentStore.getTorrentByHash(hash)!.name }.torrent`, new BlobReader(blob))))
+    hashes.value.map(hash => torrentStore.exportTorrent(hash).then(blob => zipWriter.add(`${torrentStore.getTorrentByHash(hash)!.name}.torrent`, new BlobReader(blob))))
   )
   downloadFile('torrents.zip', await zipWriter.close())
 }
@@ -265,7 +257,7 @@ const menuData = computed<RightClickMenuEntryType[]>(() => [
         action: async () => await toggleTag(tag).then(maindataStore.forceMaindataSync)
       }))
     ]
-},
+  },
   {
     text: t('dashboard.right_click.category.title'),
     icon: 'mdi-label',

--- a/src/components/Dialogs/CategoryFormDialog.vue
+++ b/src/components/Dialogs/CategoryFormDialog.vue
@@ -12,7 +12,7 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  'submit': [Category]
+  submit: [Category]
 }>()
 
 const { t } = useI18n()

--- a/src/components/Dialogs/ConfirmDeleteDialog.vue
+++ b/src/components/Dialogs/ConfirmDeleteDialog.vue
@@ -30,7 +30,7 @@ const selection = computed(() => torrentStore.torrents.filter(t => props.hashes?
 const _deleteWithFiles = ref(preferenceStore.preferences!.delete_torrent_content_files ?? vuetorrentStore.deleteWithFiles)
 const deleteWithFiles = computed({
   get: () => _deleteWithFiles.value,
-  set: (v) => (vuetorrentStore.deleteWithFiles = v)
+  set: v => (vuetorrentStore.deleteWithFiles = v)
 })
 
 async function submit() {

--- a/src/components/Dialogs/ConfirmDeleteDialog.vue
+++ b/src/components/Dialogs/ConfirmDeleteDialog.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useDialog } from '@/composables'
-import { useDashboardStore, useTorrentStore, useVueTorrentStore } from '@/stores'
+import { useDashboardStore, usePreferenceStore, useTorrentStore, useVueTorrentStore } from '@/stores'
 import { computed, onBeforeMount, onUnmounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRoute, useRouter } from 'vue-router'
@@ -17,6 +17,7 @@ const route = useRoute()
 const router = useRouter()
 const { t } = useI18n()
 const dashboardStore = useDashboardStore()
+const preferenceStore = usePreferenceStore()
 const torrentStore = useTorrentStore()
 const vuetorrentStore = useVueTorrentStore()
 
@@ -24,6 +25,13 @@ const form = ref<VForm>()
 const isFormValid = ref(false)
 
 const selection = computed(() => torrentStore.torrents.filter(t => props.hashes?.includes(t.hash)))
+
+// TODO: Save state directly from here (qbit 5.X only)
+const _deleteWithFiles = ref(preferenceStore.preferences!.delete_torrent_content_files ?? vuetorrentStore.deleteWithFiles)
+const deleteWithFiles = computed({
+  get: () => _deleteWithFiles.value,
+  set: (v) => (vuetorrentStore.deleteWithFiles = v)
+})
 
 async function submit() {
   if (!isFormValid.value) return
@@ -71,9 +79,9 @@ onUnmounted(() => {
           <div class="d-flex flex-wrap flex-gap-small">
             <span class="pa-1 border wrap-anywhere" v-for="torrent in selection">{{ torrent.name }}</span>
           </div>
-          <v-checkbox v-model="vuetorrentStore.deleteWithFiles" hide-details :label="$t('dialogs.delete.deleteWithFiles')" />
+          <v-checkbox v-model="deleteWithFiles" hide-details :label="$t('dialogs.delete.deleteWithFiles')" />
           <v-scroll-x-transition>
-            <div class="text-red" v-show="vuetorrentStore.deleteWithFiles">
+            <div class="text-red" v-show="deleteWithFiles">
               <v-icon>mdi-alert</v-icon>
               {{ $t('dialogs.delete.warnDelete') }}
             </div>

--- a/src/components/Dialogs/TagFormDialog.vue
+++ b/src/components/Dialogs/TagFormDialog.vue
@@ -11,7 +11,7 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
-  'submit': [string[]]
+  submit: [string[]]
 }>()
 
 const { isOpened } = useDialog(props.guid)

--- a/src/components/Settings/Advanced.vue
+++ b/src/components/Settings/Advanced.vue
@@ -1,16 +1,29 @@
 <script setup lang="ts">
-import { DiskIOMode, DiskIOType, ResumeDataStorageType, UploadChokingAlgorithm, UploadSlotsBehavior, UtpTcpMixedMode } from '@/constants/qbit/AppPreferences'
+import {
+  DiskIOMode,
+  DiskIOType,
+  ResumeDataStorageType,
+  TorrentContentRemoveOption,
+  UploadChokingAlgorithm,
+  UploadSlotsBehavior,
+  UtpTcpMixedMode
+} from '@/constants/qbit/AppPreferences'
 import qbit from '@/services/qbit'
-import { usePreferenceStore } from '@/stores'
+import { useAppStore, usePreferenceStore } from '@/stores'
 import { computed, onBeforeMount, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
+const appStore = useAppStore()
 const preferenceStore = usePreferenceStore()
 
 const resumeDataStorageTypeOptions = [
   { title: t('settings.advanced.qbittorrent.resumeDataStorageType.legacy'), value: ResumeDataStorageType.LEGACY },
   { title: t('settings.advanced.qbittorrent.resumeDataStorageType.sqlite'), value: ResumeDataStorageType.SQLITE }
+]
+const torrentContentRemovingMode = [
+  { title: t('constants.torrentContentRemovingMode.delete'), value: TorrentContentRemoveOption.DELETE },
+  { title: t('constants.torrentContentRemovingMode.moveToTrash'), value: TorrentContentRemoveOption.MOVE_TO_TRASH }
 ]
 const networkInterfaceOptions = ref([
   {
@@ -77,35 +90,50 @@ onBeforeMount(async () => {
       {{ t('settings.advanced.qbittorrent.subheader') }} (<a
         href="https://github.com/qbittorrent/qBittorrent/wiki/Explanation-of-Options-in-qBittorrent#Advanced"
         target="_blank"
-        >{{ t('settings.advanced.openDoc') }}</a
-      >)
+    >{{ t('settings.advanced.openDoc') }}</a
+    >)
     </v-list-subheader>
 
     <v-list-item>
       <v-row>
         <v-col cols="12" sm="6">
           <v-select
-            v-model="preferenceStore.preferences!.resume_data_storage_type"
-            hide-details
-            :items="resumeDataStorageTypeOptions"
-            :label="$t('settings.advanced.qbittorrent.resumeDataStorageType.label')" />
+              v-model="preferenceStore.preferences!.resume_data_storage_type"
+              hide-details
+              :items="resumeDataStorageTypeOptions"
+              :label="$t('settings.advanced.qbittorrent.resumeDataStorageType.label')" />
         </v-col>
         <v-col cols="12" sm="6">
           <v-text-field
-            v-model.number="preferenceStore.preferences!.save_resume_data_interval"
-            type="number"
-            hide-details
-            :suffix="t('units.minutes', preferenceStore.preferences!.save_resume_data_interval)"
-            :label="t('settings.advanced.qbittorrent.saveInterval')" />
+              v-model.number="preferenceStore.preferences!.save_resume_data_interval"
+              type="number"
+              hide-details
+              :suffix="t('units.minutes', preferenceStore.preferences!.save_resume_data_interval)"
+              :label="t('settings.advanced.qbittorrent.saveInterval')" />
         </v-col>
+
+        <template v-if="appStore.version >= '5.0.0'">
+          <v-col cols="12">
+            <v-select
+                v-model="preferenceStore.preferences!.torrent_content_remove_option"
+                :items="torrentContentRemovingMode"
+                hide-details
+                :label="t('settings.advanced.qbittorrent.torrentContentRemovingMode')" />
+          </v-col>
+          <v-col cols="12">
+            <v-text-field v-model="preferenceStore.preferences!.app_instance_name"
+                          hide-details
+                          :label="t('settings.Advanced.qbittorrent.appInstanceName')" />
+          </v-col>
+        </template>
 
         <v-col cols="12" sm="6">
           <v-text-field
-            v-model.number="preferenceStore.preferences!.memory_working_set_limit"
-            type="number"
-            hide-details
-            suffix="MiB"
-            :label="t('settings.advanced.qbittorrent.allocatedRam')" />
+              v-model.number="preferenceStore.preferences!.memory_working_set_limit"
+              type="number"
+              hide-details
+              suffix="MiB"
+              :label="t('settings.advanced.qbittorrent.allocatedRam')" />
         </v-col>
         <v-col cols="12" sm="6">
           <v-text-field v-model.number="torrentFileSizeLimit" type="number" hide-details suffix="MiB" :label="$t('settings.advanced.qbittorrent.torrentFileSizeLimit')" />
@@ -116,11 +144,11 @@ onBeforeMount(async () => {
         </v-col>
         <v-col cols="12" sm="6">
           <v-text-field
-            v-model.number="preferenceStore.preferences!.refresh_interval"
-            type="number"
-            hide-details
-            suffix="ms"
-            :label="t('settings.advanced.qbittorrent.refreshInterval')" />
+              v-model.number="preferenceStore.preferences!.refresh_interval"
+              type="number"
+              hide-details
+              suffix="ms"
+              :label="t('settings.advanced.qbittorrent.refreshInterval')" />
         </v-col>
 
         <v-col cols="12" sm="6">
@@ -139,17 +167,17 @@ onBeforeMount(async () => {
       <v-row>
         <v-col cols="12" sm="6">
           <v-select
-            v-model="preferenceStore.preferences!.current_network_interface"
-            hide-details
-            :items="networkInterfaceOptions"
-            :label="t('settings.advanced.qbittorrent.networking.networkInterfaces.label')" />
+              v-model="preferenceStore.preferences!.current_network_interface"
+              hide-details
+              :items="networkInterfaceOptions"
+              :label="t('settings.advanced.qbittorrent.networking.networkInterfaces.label')" />
         </v-col>
         <v-col cols="12" sm="6">
           <v-select
-            v-model="preferenceStore.preferences!.current_interface_address"
-            hide-details
-            :items="ipAddressesOptions"
-            :label="t('settings.advanced.qbittorrent.networking.ipAddress.label')" />
+              v-model="preferenceStore.preferences!.current_interface_address"
+              hide-details
+              :items="ipAddressesOptions"
+              :label="t('settings.advanced.qbittorrent.networking.ipAddress.label')" />
         </v-col>
       </v-row>
     </v-list-item>
@@ -164,20 +192,33 @@ onBeforeMount(async () => {
         </v-col>
         <v-col cols="12" class="py-0">
           <v-text-field
-            v-model.number="preferenceStore.preferences!.embedded_tracker_port"
-            :disabled="!preferenceStore.preferences!.enable_embedded_tracker"
-            type="number"
-            hide-details
-            :label="t('settings.advanced.qbittorrent.embeddedTracker.port')" />
+              v-model.number="preferenceStore.preferences!.embedded_tracker_port"
+              :disabled="!preferenceStore.preferences!.enable_embedded_tracker"
+              type="number"
+              hide-details
+              :label="t('settings.advanced.qbittorrent.embeddedTracker.port')" />
         </v-col>
         <v-col cols="12" class="pt-0">
           <v-checkbox
-            v-model="preferenceStore.preferences!.embedded_tracker_port_forwarding"
-            hide-details
-            :label="t('settings.advanced.qbittorrent.embeddedTracker.portForward')" />
+              v-model="preferenceStore.preferences!.embedded_tracker_port_forwarding"
+              hide-details
+              :label="t('settings.advanced.qbittorrent.embeddedTracker.portForward')" />
         </v-col>
       </v-row>
     </v-list-item>
+
+    <template v-if="appStore.version >= '5.0.0'">
+      <v-divider class="mx-10 mt-3" />
+      <v-list-item>
+        <v-row>
+          <v-col cols="12">
+            <v-checkbox v-model="preferenceStore.preferences!.mark_of_the_web" hide-details
+                        :label="t('settings.advanced.qbittorrent.enableMarkOfTheWeb')"
+                        :hint="t('settings.advanced.qbittorrent.enableMarkOfTheWebHint')" />
+          </v-col>
+        </v-row>
+      </v-list-item>
+    </template>
 
     <v-divider />
 
@@ -195,17 +236,17 @@ onBeforeMount(async () => {
       <v-row>
         <v-col cols="12" sm="6">
           <v-text-field
-            v-model.number="preferenceStore.preferences!.async_io_threads"
-            type="number"
-            hide-details
-            :label="t('settings.advanced.libtorrent.threads.asyncIoThreads')" />
+              v-model.number="preferenceStore.preferences!.async_io_threads"
+              type="number"
+              hide-details
+              :label="t('settings.advanced.libtorrent.threads.asyncIoThreads')" />
         </v-col>
         <v-col cols="12" sm="6">
           <v-text-field
-            v-model.number="preferenceStore.preferences!.hashing_threads"
-            type="number"
-            hide-details
-            :label="t('settings.advanced.libtorrent.threads.hashingThreads')" />
+              v-model.number="preferenceStore.preferences!.hashing_threads"
+              type="number"
+              hide-details
+              :label="t('settings.advanced.libtorrent.threads.hashingThreads')" />
         </v-col>
 
         <v-col cols="12" sm="6">
@@ -213,11 +254,11 @@ onBeforeMount(async () => {
         </v-col>
         <v-col cols="12" sm="6">
           <v-text-field
-            v-model.number="preferenceStore.preferences!.checking_memory_use"
-            type="number"
-            hide-details
-            suffix="MiB"
-            :label="t('settings.advanced.libtorrent.threads.outstandingMemory')" />
+              v-model.number="preferenceStore.preferences!.checking_memory_use"
+              type="number"
+              hide-details
+              suffix="MiB"
+              :label="t('settings.advanced.libtorrent.threads.outstandingMemory')" />
         </v-col>
       </v-row>
     </v-list-item>
@@ -229,28 +270,28 @@ onBeforeMount(async () => {
       <v-row>
         <v-col cols="12" sm="6">
           <v-text-field
-            v-model.number="preferenceStore.preferences!.disk_cache"
-            type="number"
-            hide-details
-            suffix="MiB"
-            :label="t('settings.advanced.libtorrent.disk.diskCache')" />
+              v-model.number="preferenceStore.preferences!.disk_cache"
+              type="number"
+              hide-details
+              suffix="MiB"
+              :label="t('settings.advanced.libtorrent.disk.diskCache')" />
         </v-col>
         <v-col cols="12" sm="6">
           <v-text-field
-            v-model.number="preferenceStore.preferences!.disk_cache_ttl"
-            type="number"
-            hide-details
-            :suffix="t('units.seconds', preferenceStore.preferences!.disk_cache_ttl)"
-            :label="t('settings.advanced.libtorrent.disk.diskCacheExpiry')" />
+              v-model.number="preferenceStore.preferences!.disk_cache_ttl"
+              type="number"
+              hide-details
+              :suffix="t('units.seconds', preferenceStore.preferences!.disk_cache_ttl)"
+              :label="t('settings.advanced.libtorrent.disk.diskCacheExpiry')" />
         </v-col>
 
         <v-col cols="12">
           <v-text-field
-            v-model.number="preferenceStore.preferences!.disk_queue_size"
-            type="number"
-            hide-details
-            suffix="kiB"
-            :label="t('settings.advanced.libtorrent.disk.diskQueueSize')" />
+              v-model.number="preferenceStore.preferences!.disk_queue_size"
+              type="number"
+              hide-details
+              suffix="kiB"
+              :label="t('settings.advanced.libtorrent.disk.diskQueueSize')" />
         </v-col>
 
         <v-col cols="12" sm="4">
@@ -258,17 +299,17 @@ onBeforeMount(async () => {
         </v-col>
         <v-col cols="12" sm="4">
           <v-select
-            v-model="preferenceStore.preferences!.disk_io_read_mode"
-            hide-details
-            :items="diskIoModeReadOptions"
-            :label="t('settings.advanced.libtorrent.disk.diskIoReadMode')" />
+              v-model="preferenceStore.preferences!.disk_io_read_mode"
+              hide-details
+              :items="diskIoModeReadOptions"
+              :label="t('settings.advanced.libtorrent.disk.diskIoReadMode')" />
         </v-col>
         <v-col cols="12" sm="4">
           <v-select
-            v-model="preferenceStore.preferences!.disk_io_write_mode"
-            hide-details
-            :items="diskIoModeWriteOptions"
-            :label="t('settings.advanced.libtorrent.disk.diskIoWriteMode')" />
+              v-model="preferenceStore.preferences!.disk_io_write_mode"
+              hide-details
+              :items="diskIoModeWriteOptions"
+              :label="t('settings.advanced.libtorrent.disk.diskIoWriteMode')" />
         </v-col>
       </v-row>
     </v-list-item>
@@ -279,17 +320,17 @@ onBeforeMount(async () => {
       <v-row>
         <v-col cols="12" sm="6">
           <v-text-field
-            v-model.number="preferenceStore.preferences!.bdecode_depth_limit"
-            type="number"
-            hide-details
-            :label="t('settings.advanced.libtorrent.threads.bdecodeDepthLimit')" />
+              v-model.number="preferenceStore.preferences!.bdecode_depth_limit"
+              type="number"
+              hide-details
+              :label="t('settings.advanced.libtorrent.threads.bdecodeDepthLimit')" />
         </v-col>
         <v-col cols="12" sm="6">
           <v-text-field
-            v-model.number="preferenceStore.preferences!.bdecode_token_limit"
-            type="number"
-            hide-details
-            :label="t('settings.advanced.libtorrent.threads.bdecodeTokenLimit')" />
+              v-model.number="preferenceStore.preferences!.bdecode_token_limit"
+              type="number"
+              hide-details
+              :label="t('settings.advanced.libtorrent.threads.bdecodeTokenLimit')" />
         </v-col>
 
         <v-col cols="12" sm="4">
@@ -304,52 +345,52 @@ onBeforeMount(async () => {
 
         <v-col cols="12" sm="4">
           <v-text-field
-            v-model.number="preferenceStore.preferences!.send_buffer_watermark"
-            type="number"
-            hide-details
-            suffix="kiB"
-            :label="t('settings.advanced.libtorrent.sendBufferWatermark')" />
+              v-model.number="preferenceStore.preferences!.send_buffer_watermark"
+              type="number"
+              hide-details
+              suffix="kiB"
+              :label="t('settings.advanced.libtorrent.sendBufferWatermark')" />
         </v-col>
         <v-col cols="12" sm="4">
           <v-text-field
-            v-model.number="preferenceStore.preferences!.send_buffer_low_watermark"
-            type="number"
-            hide-details
-            suffix="kiB"
-            :label="t('settings.advanced.libtorrent.sendBufferLowWatermark')" />
+              v-model.number="preferenceStore.preferences!.send_buffer_low_watermark"
+              type="number"
+              hide-details
+              suffix="kiB"
+              :label="t('settings.advanced.libtorrent.sendBufferLowWatermark')" />
         </v-col>
         <v-col cols="12" sm="4">
           <v-text-field
-            v-model.number="preferenceStore.preferences!.send_buffer_watermark_factor"
-            type="number"
-            hide-details
-            suffix="%"
-            :label="t('settings.advanced.libtorrent.sendBufferWatermarkFactor')" />
+              v-model.number="preferenceStore.preferences!.send_buffer_watermark_factor"
+              type="number"
+              hide-details
+              suffix="%"
+              :label="t('settings.advanced.libtorrent.sendBufferWatermarkFactor')" />
         </v-col>
 
         <v-col cols="12">
           <v-text-field
-            v-model.number="preferenceStore.preferences!.connection_speed"
-            type="number"
-            hide-details
-            :label="t('settings.advanced.libtorrent.outgoingConnectionsPerSecond')" />
+              v-model.number="preferenceStore.preferences!.connection_speed"
+              type="number"
+              hide-details
+              :label="t('settings.advanced.libtorrent.outgoingConnectionsPerSecond')" />
         </v-col>
 
         <v-col cols="12" sm="4">
           <v-text-field
-            v-model.number="preferenceStore.preferences!.socket_send_buffer_size"
-            type="number"
-            :label="t('settings.advanced.libtorrent.socketSendBufferSize')"
-            :hint="$t('settings.advanced.libtorrent.socketSendBufferSizeHint')"
-            suffix="kiB" />
+              v-model.number="preferenceStore.preferences!.socket_send_buffer_size"
+              type="number"
+              :label="t('settings.advanced.libtorrent.socketSendBufferSize')"
+              :hint="$t('settings.advanced.libtorrent.socketSendBufferSizeHint')"
+              suffix="kiB" />
         </v-col>
         <v-col cols="12" sm="4">
           <v-text-field
-            v-model.number="preferenceStore.preferences!.socket_receive_buffer_size"
-            type="number"
-            :label="t('settings.advanced.libtorrent.socketReceiveBufferSize')"
-            :hint="$t('settings.advanced.libtorrent.socketReceiveBufferSizeHint')"
-            suffix="kiB" />
+              v-model.number="preferenceStore.preferences!.socket_receive_buffer_size"
+              type="number"
+              :label="t('settings.advanced.libtorrent.socketReceiveBufferSize')"
+              :hint="$t('settings.advanced.libtorrent.socketReceiveBufferSizeHint')"
+              suffix="kiB" />
         </v-col>
         <v-col cols="12" sm="4">
           <v-text-field v-model.number="preferenceStore.preferences!.socket_backlog_size" type="number" hide-details :label="t('settings.advanced.libtorrent.socketBacklogSize')" />
@@ -364,25 +405,25 @@ onBeforeMount(async () => {
       <v-row>
         <v-col cols="12" sm="6">
           <v-text-field
-            v-model.number="preferenceStore.preferences!.outgoing_ports_min"
-            type="number"
-            hide-details
-            :label="t('settings.advanced.libtorrent.networking.outgoingPortsMin')" />
+              v-model.number="preferenceStore.preferences!.outgoing_ports_min"
+              type="number"
+              hide-details
+              :label="t('settings.advanced.libtorrent.networking.outgoingPortsMin')" />
         </v-col>
         <v-col cols="12" sm="6">
           <v-text-field
-            v-model.number="preferenceStore.preferences!.outgoing_ports_max"
-            type="number"
-            hide-details
-            :label="t('settings.advanced.libtorrent.networking.outgoingPortsMax')" />
+              v-model.number="preferenceStore.preferences!.outgoing_ports_max"
+              type="number"
+              hide-details
+              :label="t('settings.advanced.libtorrent.networking.outgoingPortsMax')" />
         </v-col>
 
         <v-col cols="12" sm="6">
           <v-text-field
-            v-model.number="preferenceStore.preferences!.upnp_lease_duration"
-            type="number"
-            hide-details
-            :label="t('settings.advanced.libtorrent.networking.upnpLeaseDuration')" />
+              v-model.number="preferenceStore.preferences!.upnp_lease_duration"
+              type="number"
+              hide-details
+              :label="t('settings.advanced.libtorrent.networking.upnpLeaseDuration')" />
         </v-col>
         <v-col cols="12" sm="6">
           <v-text-field v-model.number="preferenceStore.preferences!.peer_tos" type="number" hide-details :label="t('settings.advanced.libtorrent.networking.peerTos')" />
@@ -390,10 +431,10 @@ onBeforeMount(async () => {
 
         <v-col cols="12">
           <v-select
-            v-model="preferenceStore.preferences!.utp_tcp_mixed_mode"
-            hide-details
-            :items="utpTcpMixedModeOptions"
-            :label="t('settings.advanced.libtorrent.networking.utpTcpMixedModeAlgorithm')" />
+              v-model="preferenceStore.preferences!.utp_tcp_mixed_mode"
+              hide-details
+              :items="utpTcpMixedModeOptions"
+              :label="t('settings.advanced.libtorrent.networking.utpTcpMixedModeAlgorithm')" />
         </v-col>
       </v-row>
     </v-list-item>
@@ -408,25 +449,25 @@ onBeforeMount(async () => {
         </v-col>
         <v-col cols="12" sm="6">
           <v-checkbox
-            v-model="preferenceStore.preferences!.enable_multi_connections_from_same_ip"
-            hide-details
-            :label="t('settings.advanced.libtorrent.security.allowMultipleConnectionsFromTheSameIPAddress')" />
+              v-model="preferenceStore.preferences!.enable_multi_connections_from_same_ip"
+              hide-details
+              :label="t('settings.advanced.libtorrent.security.allowMultipleConnectionsFromTheSameIPAddress')" />
         </v-col>
 
         <v-col cols="12" sm="4">
           <v-checkbox
-            v-model="preferenceStore.preferences!.validate_https_tracker_certificate"
-            hide-details
-            :label="t('settings.advanced.libtorrent.security.validateHTTPSTrackerCertificate')" />
+              v-model="preferenceStore.preferences!.validate_https_tracker_certificate"
+              hide-details
+              :label="t('settings.advanced.libtorrent.security.validateHTTPSTrackerCertificate')" />
         </v-col>
         <v-col cols="12" sm="4">
           <v-checkbox v-model="preferenceStore.preferences!.ssrf_mitigation" hide-details :label="t('settings.advanced.libtorrent.security.mitigateSSRF')" />
         </v-col>
         <v-col cols="12" sm="4">
           <v-checkbox
-            v-model="preferenceStore.preferences!.block_peers_on_privileged_ports"
-            hide-details
-            :label="t('settings.advanced.libtorrent.security.blockPeersOnPrivilegedPorts')" />
+              v-model="preferenceStore.preferences!.block_peers_on_privileged_ports"
+              hide-details
+              :label="t('settings.advanced.libtorrent.security.blockPeersOnPrivilegedPorts')" />
         </v-col>
       </v-row>
     </v-list-item>
@@ -437,17 +478,17 @@ onBeforeMount(async () => {
       <v-row>
         <v-col cols="12" sm="6">
           <v-select
-            v-model="preferenceStore.preferences!.upload_slots_behavior"
-            hide-details
-            :items="uploadSlotsBehaviorOptions"
-            :label="t('settings.advanced.libtorrent.uploadSlotsBehavior')" />
+              v-model="preferenceStore.preferences!.upload_slots_behavior"
+              hide-details
+              :items="uploadSlotsBehaviorOptions"
+              :label="t('settings.advanced.libtorrent.uploadSlotsBehavior')" />
         </v-col>
         <v-col cols="12" sm="6">
           <v-select
-            v-model="preferenceStore.preferences!.upload_choking_algorithm"
-            hide-details
-            :items="uploadChokingAlgorithmOptions"
-            :label="t('settings.advanced.libtorrent.uploadChokingAlgorithm')" />
+              v-model="preferenceStore.preferences!.upload_choking_algorithm"
+              hide-details
+              :items="uploadChokingAlgorithmOptions"
+              :label="t('settings.advanced.libtorrent.uploadChokingAlgorithm')" />
         </v-col>
 
         <v-col cols="12" sm="6">
@@ -463,17 +504,17 @@ onBeforeMount(async () => {
 
         <v-col cols="12" sm="6">
           <v-text-field
-            v-model.number="preferenceStore.preferences!.max_concurrent_http_announces"
-            type="number"
-            hide-details
-            :label="t('settings.advanced.libtorrent.maxConcurrentHTTPAnnounces')" />
+              v-model.number="preferenceStore.preferences!.max_concurrent_http_announces"
+              type="number"
+              hide-details
+              :label="t('settings.advanced.libtorrent.maxConcurrentHTTPAnnounces')" />
         </v-col>
         <v-col cols="12" sm="6">
           <v-text-field
-            v-model.number="preferenceStore.preferences!.stop_tracker_timeout"
-            type="number"
-            hide-details
-            :label="t('settings.advanced.libtorrent.stopTrackerTimeout')" />
+              v-model.number="preferenceStore.preferences!.stop_tracker_timeout"
+              type="number"
+              hide-details
+              :label="t('settings.advanced.libtorrent.stopTrackerTimeout')" />
         </v-col>
 
         <v-col cols="12" sm="4">
@@ -481,19 +522,19 @@ onBeforeMount(async () => {
         </v-col>
         <v-col cols="12" sm="4">
           <v-text-field
-            v-model.number="preferenceStore.preferences!.peer_turnover_cutoff"
-            type="number"
-            hide-details
-            suffix="%"
-            :label="t('settings.advanced.libtorrent.peerTurnoverCutoff')" />
+              v-model.number="preferenceStore.preferences!.peer_turnover_cutoff"
+              type="number"
+              hide-details
+              suffix="%"
+              :label="t('settings.advanced.libtorrent.peerTurnoverCutoff')" />
         </v-col>
         <v-col cols="12" sm="4">
           <v-text-field
-            v-model.number="preferenceStore.preferences!.peer_turnover_interval"
-            type="number"
-            hide-details
-            :suffix="t('units.seconds', preferenceStore.preferences!.peer_turnover_interval)"
-            :label="t('settings.advanced.libtorrent.peerTurnoverInterval')" />
+              v-model.number="preferenceStore.preferences!.peer_turnover_interval"
+              type="number"
+              hide-details
+              :suffix="t('units.seconds', preferenceStore.preferences!.peer_turnover_interval)"
+              :label="t('settings.advanced.libtorrent.peerTurnoverInterval')" />
         </v-col>
 
         <v-col cols="12">

--- a/src/components/Settings/Advanced.vue
+++ b/src/components/Settings/Advanced.vue
@@ -10,12 +10,13 @@ import {
 } from '@/constants/qbit/AppPreferences'
 import qbit from '@/services/qbit'
 import { useAppStore, usePreferenceStore } from '@/stores'
+import { storeToRefs } from 'pinia'
 import { computed, onBeforeMount, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
 const appStore = useAppStore()
-const preferenceStore = usePreferenceStore()
+const { preferences: pref } = storeToRefs(usePreferenceStore())
 
 const resumeDataStorageTypeOptions = [
   { title: t('settings.advanced.qbittorrent.resumeDataStorageType.legacy'), value: ResumeDataStorageType.LEGACY },
@@ -65,9 +66,9 @@ const uploadChokingAlgorithmOptions = [
 ]
 
 const torrentFileSizeLimit = computed({
-  get: () => preferenceStore.preferences!.torrent_file_size_limit / 1024 / 1024,
+  get: () => pref.value!.torrent_file_size_limit / 1024 / 1024,
   set: (value: number) => {
-    preferenceStore.preferences!.torrent_file_size_limit = value * 1024 * 1024
+    pref.value!.torrent_file_size_limit = value * 1024 * 1024
   }
 })
 
@@ -77,7 +78,7 @@ onBeforeMount(async () => {
     networkInterfaceOptions.value.push({ title: networkInterface.name, value: networkInterface.value })
   }
 
-  const ipAddresses = await qbit.getAddresses(preferenceStore.preferences!.current_network_interface)
+  const ipAddresses = await qbit.getAddresses(pref.value!.current_network_interface)
   for (const ipAddress of ipAddresses) {
     ipAddressesOptions.value.push({ title: ipAddress, value: ipAddress })
   }
@@ -98,30 +99,30 @@ onBeforeMount(async () => {
       <v-row>
         <v-col cols="12" sm="6">
           <v-select
-              v-model="preferenceStore.preferences!.resume_data_storage_type"
+              v-model="pref!.resume_data_storage_type"
               hide-details
               :items="resumeDataStorageTypeOptions"
-              :label="$t('settings.advanced.qbittorrent.resumeDataStorageType.label')" />
+              :label="t('settings.advanced.qbittorrent.resumeDataStorageType.label')" />
         </v-col>
         <v-col cols="12" sm="6">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.save_resume_data_interval"
+              v-model.number="pref!.save_resume_data_interval"
               type="number"
               hide-details
-              :suffix="t('units.minutes', preferenceStore.preferences!.save_resume_data_interval)"
+              :suffix="t('units.minutes', pref!.save_resume_data_interval)"
               :label="t('settings.advanced.qbittorrent.saveInterval')" />
         </v-col>
 
         <template v-if="appStore.version >= '5.0.0'">
           <v-col cols="12">
             <v-select
-                v-model="preferenceStore.preferences!.torrent_content_remove_option"
+                v-model="pref!.torrent_content_remove_option"
                 :items="torrentContentRemovingMode"
                 hide-details
                 :label="t('settings.advanced.qbittorrent.torrentContentRemovingMode')" />
           </v-col>
           <v-col cols="12">
-            <v-text-field v-model="preferenceStore.preferences!.app_instance_name"
+            <v-text-field v-model="pref!.app_instance_name"
                           hide-details
                           :label="t('settings.Advanced.qbittorrent.appInstanceName')" />
           </v-col>
@@ -129,22 +130,22 @@ onBeforeMount(async () => {
 
         <v-col cols="12" sm="6">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.memory_working_set_limit"
+              v-model.number="pref!.memory_working_set_limit"
               type="number"
               hide-details
               suffix="MiB"
               :label="t('settings.advanced.qbittorrent.allocatedRam')" />
         </v-col>
         <v-col cols="12" sm="6">
-          <v-text-field v-model.number="torrentFileSizeLimit" type="number" hide-details suffix="MiB" :label="$t('settings.advanced.qbittorrent.torrentFileSizeLimit')" />
+          <v-text-field v-model.number="torrentFileSizeLimit" type="number" hide-details suffix="MiB" :label="t('settings.advanced.qbittorrent.torrentFileSizeLimit')" />
         </v-col>
 
         <v-col cols="12" sm="6">
-          <v-checkbox v-model="preferenceStore.preferences!.recheck_completed_torrents" hide-details :label="t('settings.advanced.qbittorrent.recheckOnCompletion')" />
+          <v-checkbox v-model="pref!.recheck_completed_torrents" hide-details :label="t('settings.advanced.qbittorrent.recheckOnCompletion')" />
         </v-col>
         <v-col cols="12" sm="6">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.refresh_interval"
+              v-model.number="pref!.refresh_interval"
               type="number"
               hide-details
               suffix="ms"
@@ -152,10 +153,10 @@ onBeforeMount(async () => {
         </v-col>
 
         <v-col cols="12" sm="6">
-          <v-checkbox v-model="preferenceStore.preferences!.resolve_peer_countries" hide-details :label="t('settings.advanced.qbittorrent.resolveCountries')" />
+          <v-checkbox v-model="pref!.resolve_peer_countries" hide-details :label="t('settings.advanced.qbittorrent.resolveCountries')" />
         </v-col>
         <v-col cols="12" sm="6">
-          <v-checkbox v-model="preferenceStore.preferences!.reannounce_when_address_changed" hide-details :label="t('settings.advanced.qbittorrent.reannounceOnIpPortChanged')" />
+          <v-checkbox v-model="pref!.reannounce_when_address_changed" hide-details :label="t('settings.advanced.qbittorrent.reannounceOnIpPortChanged')" />
         </v-col>
       </v-row>
     </v-list-item>
@@ -167,14 +168,14 @@ onBeforeMount(async () => {
       <v-row>
         <v-col cols="12" sm="6">
           <v-select
-              v-model="preferenceStore.preferences!.current_network_interface"
+              v-model="pref!.current_network_interface"
               hide-details
               :items="networkInterfaceOptions"
               :label="t('settings.advanced.qbittorrent.networking.networkInterfaces.label')" />
         </v-col>
         <v-col cols="12" sm="6">
           <v-select
-              v-model="preferenceStore.preferences!.current_interface_address"
+              v-model="pref!.current_interface_address"
               hide-details
               :items="ipAddressesOptions"
               :label="t('settings.advanced.qbittorrent.networking.ipAddress.label')" />
@@ -188,19 +189,19 @@ onBeforeMount(async () => {
     <v-list-item>
       <v-row>
         <v-col cols="12" class="py-0">
-          <v-checkbox v-model="preferenceStore.preferences!.enable_embedded_tracker" hide-details :label="t('settings.advanced.qbittorrent.embeddedTracker.enable')" />
+          <v-checkbox v-model="pref!.enable_embedded_tracker" hide-details :label="t('settings.advanced.qbittorrent.embeddedTracker.enable')" />
         </v-col>
         <v-col cols="12" class="py-0">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.embedded_tracker_port"
-              :disabled="!preferenceStore.preferences!.enable_embedded_tracker"
+              v-model.number="pref!.embedded_tracker_port"
+              :disabled="!pref!.enable_embedded_tracker"
               type="number"
               hide-details
               :label="t('settings.advanced.qbittorrent.embeddedTracker.port')" />
         </v-col>
         <v-col cols="12" class="pt-0">
           <v-checkbox
-              v-model="preferenceStore.preferences!.embedded_tracker_port_forwarding"
+              v-model="pref!.embedded_tracker_port_forwarding"
               hide-details
               :label="t('settings.advanced.qbittorrent.embeddedTracker.portForward')" />
         </v-col>
@@ -212,9 +213,17 @@ onBeforeMount(async () => {
       <v-list-item>
         <v-row>
           <v-col cols="12">
-            <v-checkbox v-model="preferenceStore.preferences!.mark_of_the_web" hide-details
+            <v-checkbox v-model="pref!.mark_of_the_web"
+                        hide-details
                         :label="t('settings.advanced.qbittorrent.enableMarkOfTheWeb')"
                         :hint="t('settings.advanced.qbittorrent.enableMarkOfTheWebHint')" />
+          </v-col>
+
+          <v-col cols="12">
+            <v-text-field v-model="pref!.python_executable_path"
+                          hide-details
+                          :label="t('settings.advanced.qbittorrent.pythonExecutablePath')"
+                          :hint="t('settings.advanced.qbittorrent.pythonExecutablePathHint')"/>
           </v-col>
         </v-row>
       </v-list-item>
@@ -236,25 +245,25 @@ onBeforeMount(async () => {
       <v-row>
         <v-col cols="12" sm="6">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.async_io_threads"
+              v-model.number="pref!.async_io_threads"
               type="number"
               hide-details
               :label="t('settings.advanced.libtorrent.threads.asyncIoThreads')" />
         </v-col>
         <v-col cols="12" sm="6">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.hashing_threads"
+              v-model.number="pref!.hashing_threads"
               type="number"
               hide-details
               :label="t('settings.advanced.libtorrent.threads.hashingThreads')" />
         </v-col>
 
         <v-col cols="12" sm="6">
-          <v-text-field v-model.number="preferenceStore.preferences!.file_pool_size" type="number" hide-details :label="t('settings.advanced.libtorrent.threads.filePoolSize')" />
+          <v-text-field v-model.number="pref!.file_pool_size" type="number" hide-details :label="t('settings.advanced.libtorrent.threads.filePoolSize')" />
         </v-col>
         <v-col cols="12" sm="6">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.checking_memory_use"
+              v-model.number="pref!.checking_memory_use"
               type="number"
               hide-details
               suffix="MiB"
@@ -270,7 +279,7 @@ onBeforeMount(async () => {
       <v-row>
         <v-col cols="12" sm="6">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.disk_cache"
+              v-model.number="pref!.disk_cache"
               type="number"
               hide-details
               suffix="MiB"
@@ -278,16 +287,16 @@ onBeforeMount(async () => {
         </v-col>
         <v-col cols="12" sm="6">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.disk_cache_ttl"
+              v-model.number="pref!.disk_cache_ttl"
               type="number"
               hide-details
-              :suffix="t('units.seconds', preferenceStore.preferences!.disk_cache_ttl)"
+              :suffix="t('units.seconds', pref!.disk_cache_ttl)"
               :label="t('settings.advanced.libtorrent.disk.diskCacheExpiry')" />
         </v-col>
 
         <v-col cols="12">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.disk_queue_size"
+              v-model.number="pref!.disk_queue_size"
               type="number"
               hide-details
               suffix="kiB"
@@ -295,18 +304,18 @@ onBeforeMount(async () => {
         </v-col>
 
         <v-col cols="12" sm="4">
-          <v-select v-model="preferenceStore.preferences!.disk_io_type" hide-details :items="diskIoTypeOptions" :label="t('settings.advanced.libtorrent.disk.diskIoType')" />
+          <v-select v-model="pref!.disk_io_type" hide-details :items="diskIoTypeOptions" :label="t('settings.advanced.libtorrent.disk.diskIoType')" />
         </v-col>
         <v-col cols="12" sm="4">
           <v-select
-              v-model="preferenceStore.preferences!.disk_io_read_mode"
+              v-model="pref!.disk_io_read_mode"
               hide-details
               :items="diskIoModeReadOptions"
               :label="t('settings.advanced.libtorrent.disk.diskIoReadMode')" />
         </v-col>
         <v-col cols="12" sm="4">
           <v-select
-              v-model="preferenceStore.preferences!.disk_io_write_mode"
+              v-model="pref!.disk_io_write_mode"
               hide-details
               :items="diskIoModeWriteOptions"
               :label="t('settings.advanced.libtorrent.disk.diskIoWriteMode')" />
@@ -320,32 +329,32 @@ onBeforeMount(async () => {
       <v-row>
         <v-col cols="12" sm="6">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.bdecode_depth_limit"
+              v-model.number="pref!.bdecode_depth_limit"
               type="number"
               hide-details
               :label="t('settings.advanced.libtorrent.threads.bdecodeDepthLimit')" />
         </v-col>
         <v-col cols="12" sm="6">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.bdecode_token_limit"
+              v-model.number="pref!.bdecode_token_limit"
               type="number"
               hide-details
               :label="t('settings.advanced.libtorrent.threads.bdecodeTokenLimit')" />
         </v-col>
 
         <v-col cols="12" sm="4">
-          <v-checkbox v-model="preferenceStore.preferences!.enable_coalesce_read_write" hide-details :label="t('settings.advanced.libtorrent.coalesceReadsWrites')" />
+          <v-checkbox v-model="pref!.enable_coalesce_read_write" hide-details :label="t('settings.advanced.libtorrent.coalesceReadsWrites')" />
         </v-col>
         <v-col cols="12" sm="4">
-          <v-checkbox v-model="preferenceStore.preferences!.enable_piece_extent_affinity" hide-details :label="t('settings.advanced.libtorrent.pieceExtentAffinity')" />
+          <v-checkbox v-model="pref!.enable_piece_extent_affinity" hide-details :label="t('settings.advanced.libtorrent.pieceExtentAffinity')" />
         </v-col>
         <v-col cols="12" sm="4">
-          <v-checkbox v-model="preferenceStore.preferences!.enable_upload_suggestions" hide-details :label="t('settings.advanced.libtorrent.sendUploadPieceSuggestions')" />
+          <v-checkbox v-model="pref!.enable_upload_suggestions" hide-details :label="t('settings.advanced.libtorrent.sendUploadPieceSuggestions')" />
         </v-col>
 
         <v-col cols="12" sm="4">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.send_buffer_watermark"
+              v-model.number="pref!.send_buffer_watermark"
               type="number"
               hide-details
               suffix="kiB"
@@ -353,7 +362,7 @@ onBeforeMount(async () => {
         </v-col>
         <v-col cols="12" sm="4">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.send_buffer_low_watermark"
+              v-model.number="pref!.send_buffer_low_watermark"
               type="number"
               hide-details
               suffix="kiB"
@@ -361,7 +370,7 @@ onBeforeMount(async () => {
         </v-col>
         <v-col cols="12" sm="4">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.send_buffer_watermark_factor"
+              v-model.number="pref!.send_buffer_watermark_factor"
               type="number"
               hide-details
               suffix="%"
@@ -370,7 +379,7 @@ onBeforeMount(async () => {
 
         <v-col cols="12">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.connection_speed"
+              v-model.number="pref!.connection_speed"
               type="number"
               hide-details
               :label="t('settings.advanced.libtorrent.outgoingConnectionsPerSecond')" />
@@ -378,22 +387,22 @@ onBeforeMount(async () => {
 
         <v-col cols="12" sm="4">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.socket_send_buffer_size"
+              v-model.number="pref!.socket_send_buffer_size"
               type="number"
               :label="t('settings.advanced.libtorrent.socketSendBufferSize')"
-              :hint="$t('settings.advanced.libtorrent.socketSendBufferSizeHint')"
+              :hint="t('settings.advanced.libtorrent.socketSendBufferSizeHint')"
               suffix="kiB" />
         </v-col>
         <v-col cols="12" sm="4">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.socket_receive_buffer_size"
+              v-model.number="pref!.socket_receive_buffer_size"
               type="number"
               :label="t('settings.advanced.libtorrent.socketReceiveBufferSize')"
-              :hint="$t('settings.advanced.libtorrent.socketReceiveBufferSizeHint')"
+              :hint="t('settings.advanced.libtorrent.socketReceiveBufferSizeHint')"
               suffix="kiB" />
         </v-col>
         <v-col cols="12" sm="4">
-          <v-text-field v-model.number="preferenceStore.preferences!.socket_backlog_size" type="number" hide-details :label="t('settings.advanced.libtorrent.socketBacklogSize')" />
+          <v-text-field v-model.number="pref!.socket_backlog_size" type="number" hide-details :label="t('settings.advanced.libtorrent.socketBacklogSize')" />
         </v-col>
       </v-row>
     </v-list-item>
@@ -405,14 +414,14 @@ onBeforeMount(async () => {
       <v-row>
         <v-col cols="12" sm="6">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.outgoing_ports_min"
+              v-model.number="pref!.outgoing_ports_min"
               type="number"
               hide-details
               :label="t('settings.advanced.libtorrent.networking.outgoingPortsMin')" />
         </v-col>
         <v-col cols="12" sm="6">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.outgoing_ports_max"
+              v-model.number="pref!.outgoing_ports_max"
               type="number"
               hide-details
               :label="t('settings.advanced.libtorrent.networking.outgoingPortsMax')" />
@@ -420,18 +429,18 @@ onBeforeMount(async () => {
 
         <v-col cols="12" sm="6">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.upnp_lease_duration"
+              v-model.number="pref!.upnp_lease_duration"
               type="number"
               hide-details
               :label="t('settings.advanced.libtorrent.networking.upnpLeaseDuration')" />
         </v-col>
         <v-col cols="12" sm="6">
-          <v-text-field v-model.number="preferenceStore.preferences!.peer_tos" type="number" hide-details :label="t('settings.advanced.libtorrent.networking.peerTos')" />
+          <v-text-field v-model.number="pref!.peer_tos" type="number" hide-details :label="t('settings.advanced.libtorrent.networking.peerTos')" />
         </v-col>
 
         <v-col cols="12">
           <v-select
-              v-model="preferenceStore.preferences!.utp_tcp_mixed_mode"
+              v-model="pref!.utp_tcp_mixed_mode"
               hide-details
               :items="utpTcpMixedModeOptions"
               :label="t('settings.advanced.libtorrent.networking.utpTcpMixedModeAlgorithm')" />
@@ -445,27 +454,27 @@ onBeforeMount(async () => {
     <v-list-item>
       <v-row>
         <v-col cols="12" sm="6">
-          <v-checkbox v-model="preferenceStore.preferences!.idn_support_enabled" hide-details :label="t('settings.advanced.libtorrent.security.idnSupport')" />
+          <v-checkbox v-model="pref!.idn_support_enabled" hide-details :label="t('settings.advanced.libtorrent.security.idnSupport')" />
         </v-col>
         <v-col cols="12" sm="6">
           <v-checkbox
-              v-model="preferenceStore.preferences!.enable_multi_connections_from_same_ip"
+              v-model="pref!.enable_multi_connections_from_same_ip"
               hide-details
               :label="t('settings.advanced.libtorrent.security.allowMultipleConnectionsFromTheSameIPAddress')" />
         </v-col>
 
         <v-col cols="12" sm="4">
           <v-checkbox
-              v-model="preferenceStore.preferences!.validate_https_tracker_certificate"
+              v-model="pref!.validate_https_tracker_certificate"
               hide-details
               :label="t('settings.advanced.libtorrent.security.validateHTTPSTrackerCertificate')" />
         </v-col>
         <v-col cols="12" sm="4">
-          <v-checkbox v-model="preferenceStore.preferences!.ssrf_mitigation" hide-details :label="t('settings.advanced.libtorrent.security.mitigateSSRF')" />
+          <v-checkbox v-model="pref!.ssrf_mitigation" hide-details :label="t('settings.advanced.libtorrent.security.mitigateSSRF')" />
         </v-col>
         <v-col cols="12" sm="4">
           <v-checkbox
-              v-model="preferenceStore.preferences!.block_peers_on_privileged_ports"
+              v-model="pref!.block_peers_on_privileged_ports"
               hide-details
               :label="t('settings.advanced.libtorrent.security.blockPeersOnPrivilegedPorts')" />
         </v-col>
@@ -478,51 +487,51 @@ onBeforeMount(async () => {
       <v-row>
         <v-col cols="12" sm="6">
           <v-select
-              v-model="preferenceStore.preferences!.upload_slots_behavior"
+              v-model="pref!.upload_slots_behavior"
               hide-details
               :items="uploadSlotsBehaviorOptions"
               :label="t('settings.advanced.libtorrent.uploadSlotsBehavior')" />
         </v-col>
         <v-col cols="12" sm="6">
           <v-select
-              v-model="preferenceStore.preferences!.upload_choking_algorithm"
+              v-model="pref!.upload_choking_algorithm"
               hide-details
               :items="uploadChokingAlgorithmOptions"
               :label="t('settings.advanced.libtorrent.uploadChokingAlgorithm')" />
         </v-col>
 
         <v-col cols="12" sm="6">
-          <v-checkbox v-model="preferenceStore.preferences!.announce_to_all_trackers" hide-details :label="t('settings.advanced.libtorrent.announceAllTrackers')" />
+          <v-checkbox v-model="pref!.announce_to_all_trackers" hide-details :label="t('settings.advanced.libtorrent.announceAllTrackers')" />
         </v-col>
         <v-col cols="12" sm="6">
-          <v-checkbox v-model="preferenceStore.preferences!.announce_to_all_tiers" hide-details :label="t('settings.advanced.libtorrent.announceAllTiers')" />
+          <v-checkbox v-model="pref!.announce_to_all_tiers" hide-details :label="t('settings.advanced.libtorrent.announceAllTiers')" />
         </v-col>
 
         <v-col cols="12">
-          <v-text-field v-model="preferenceStore.preferences!.announce_ip" hide-details :label="t('settings.advanced.libtorrent.announceIP')" />
+          <v-text-field v-model="pref!.announce_ip" hide-details :label="t('settings.advanced.libtorrent.announceIP')" />
         </v-col>
 
         <v-col cols="12" sm="6">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.max_concurrent_http_announces"
+              v-model.number="pref!.max_concurrent_http_announces"
               type="number"
               hide-details
               :label="t('settings.advanced.libtorrent.maxConcurrentHTTPAnnounces')" />
         </v-col>
         <v-col cols="12" sm="6">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.stop_tracker_timeout"
+              v-model.number="pref!.stop_tracker_timeout"
               type="number"
               hide-details
               :label="t('settings.advanced.libtorrent.stopTrackerTimeout')" />
         </v-col>
 
         <v-col cols="12" sm="4">
-          <v-text-field v-model.number="preferenceStore.preferences!.peer_turnover" type="number" hide-details suffix="%" :label="t('settings.advanced.libtorrent.peerTurnover')" />
+          <v-text-field v-model.number="pref!.peer_turnover" type="number" hide-details suffix="%" :label="t('settings.advanced.libtorrent.peerTurnover')" />
         </v-col>
         <v-col cols="12" sm="4">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.peer_turnover_cutoff"
+              v-model.number="pref!.peer_turnover_cutoff"
               type="number"
               hide-details
               suffix="%"
@@ -530,19 +539,55 @@ onBeforeMount(async () => {
         </v-col>
         <v-col cols="12" sm="4">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.peer_turnover_interval"
+              v-model.number="pref!.peer_turnover_interval"
               type="number"
               hide-details
-              :suffix="t('units.seconds', preferenceStore.preferences!.peer_turnover_interval)"
+              :suffix="t('units.seconds', pref!.peer_turnover_interval)"
               :label="t('settings.advanced.libtorrent.peerTurnoverInterval')" />
         </v-col>
 
         <v-col cols="12">
-          <v-text-field v-model.number="preferenceStore.preferences!.request_queue_size" type="number" hide-details :label="t('settings.advanced.libtorrent.requestQueueSize')" />
+          <v-text-field v-model.number="pref!.request_queue_size" type="number" hide-details :label="t('settings.advanced.libtorrent.requestQueueSize')" />
+        </v-col>
+
+        <v-col cols="12">
+          <v-text-field v-model="pref!.dht_bootstrap_nodes"
+                        :label="t('settings.advanced.libtorrent.dhtBootstrapNodes')"
+                        :hint="t('settings.advanced.libtorrent.dhtBootstrapNodesHint')" />
         </v-col>
       </v-row>
     </v-list-item>
+
+    <template  v-if="appStore.version >= '5.0.0'">
+      <v-list-item>
+        <v-row>
+          <v-col cols="12">
+            <h5 class="font-italic">{{ t('settings.advanced.libtorrent.i2p.restartNeeded') }}</h5>
+          </v-col>
+
+          <v-col cols="12">
+            <v-text-field v-model="pref!.i2p_inbound_quantity" type="number" min="1" max="16" hide-details :label="t('settings.advanced.libtorrent.i2p.inboundQuantity')" />
+          </v-col>
+          <v-col cols="12">
+            <v-text-field v-model="pref!.i2p_outbound_quantity" type="number" min="1" max="16" hide-details :label="t('settings.advanced.libtorrent.i2p.outboundQuantity')" />
+          </v-col>
+          <v-col cols="12">
+            <v-text-field v-model="pref!.i2p_inbound_length" type="number" min="0" max="7" hide-details :label="t('settings.advanced.libtorrent.i2p.inboundLength')" />
+          </v-col>
+          <v-col cols="12">
+            <v-text-field v-model="pref!.i2p_outbound_length" type="number" min="0" max="7" hide-details :label="t('settings.advanced.libtorrent.i2p.outboundLength')" />
+          </v-col>
+        </v-row>
+
+        <v-row>
+          <v-col cols="12">
+            <v-checkbox v-model="pref!.ssl_enabled" hide-details :label="t('settings.advanced.libtorrent.ssl.enabled')" />
+          </v-col>
+          <v-col cols="12">
+            <v-text-field v-model="pref!.ssl_listen_port" type="number" min="0" max="65535" hide-details :label="t('settings.advanced.libtorrent.ssl.listenPort')" :hint="t('settings.advanced.libtorrent.ssl.listenPortHint')" />
+          </v-col>
+        </v-row>
+      </v-list-item>
+    </template>
   </v-list>
 </template>
-
-<style scoped lang="scss"></style>

--- a/src/components/Settings/Advanced.vue
+++ b/src/components/Settings/Advanced.vue
@@ -65,17 +65,11 @@ const uploadChokingAlgorithmOptions = [
   { title: t('constants.uploadChokingAlgorithm.antiLeech'), value: UploadChokingAlgorithm.ANTI_LEECH }
 ]
 
-const i2pQuantityRules = [
-  (v: number) => v >= 1 && v <= 16 || t('settings.advanced.libtorrent.i2p.invalidQuantity')
-]
+const i2pQuantityRules = [(v: number) => (v >= 1 && v <= 16) || t('settings.advanced.libtorrent.i2p.invalidQuantity')]
 
-const i2pLengthRules = [
-  (v: number) => v >= 0 && v <= 7 || t('settings.advanced.libtorrent.i2p.invalidLength')
-]
+const i2pLengthRules = [(v: number) => (v >= 0 && v <= 7) || t('settings.advanced.libtorrent.i2p.invalidLength')]
 
-const sslRules = [
-  (v: number) => v >= 0 && v <= 65535 || t('settings.advanced.libtorrent.ssl.rule')
-]
+const sslRules = [(v: number) => (v >= 0 && v <= 65535) || t('settings.advanced.libtorrent.ssl.rule')]
 
 const torrentFileSizeLimit = computed({
   get: () => pref.value!.torrent_file_size_limit / 1024 / 1024,
@@ -103,50 +97,43 @@ onBeforeMount(async () => {
       {{ t('settings.advanced.qbittorrent.subheader') }} (<a
         href="https://github.com/qbittorrent/qBittorrent/wiki/Explanation-of-Options-in-qBittorrent#Advanced"
         target="_blank"
-    >{{ t('settings.advanced.openDoc') }}</a
-    >)
+        >{{ t('settings.advanced.openDoc') }}</a
+      >)
     </v-list-subheader>
 
     <v-list-item>
       <v-row>
         <v-col cols="12" sm="6">
           <v-select
-              v-model="pref!.resume_data_storage_type"
-              hide-details
-              :items="resumeDataStorageTypeOptions"
-              :label="t('settings.advanced.qbittorrent.resumeDataStorageType.label')" />
+            v-model="pref!.resume_data_storage_type"
+            hide-details
+            :items="resumeDataStorageTypeOptions"
+            :label="t('settings.advanced.qbittorrent.resumeDataStorageType.label')" />
         </v-col>
         <v-col cols="12" sm="6">
           <v-text-field
-              v-model.number="pref!.save_resume_data_interval"
-              type="number"
-              hide-details
-              :suffix="t('units.minutes', pref!.save_resume_data_interval)"
-              :label="t('settings.advanced.qbittorrent.saveInterval')" />
+            v-model.number="pref!.save_resume_data_interval"
+            type="number"
+            hide-details
+            :suffix="t('units.minutes', pref!.save_resume_data_interval)"
+            :label="t('settings.advanced.qbittorrent.saveInterval')" />
         </v-col>
 
         <template v-if="appStore.version >= '5.0.0'">
           <v-col cols="12">
             <v-select
-                v-model="pref!.torrent_content_remove_option"
-                :items="torrentContentRemovingMode"
-                hide-details
-                :label="t('settings.advanced.qbittorrent.torrentContentRemovingMode')" />
+              v-model="pref!.torrent_content_remove_option"
+              :items="torrentContentRemovingMode"
+              hide-details
+              :label="t('settings.advanced.qbittorrent.torrentContentRemovingMode')" />
           </v-col>
           <v-col cols="12">
-            <v-text-field v-model="pref!.app_instance_name"
-                          hide-details
-                          :label="t('settings.advanced.qbittorrent.appInstanceName')" />
+            <v-text-field v-model="pref!.app_instance_name" hide-details :label="t('settings.advanced.qbittorrent.appInstanceName')" />
           </v-col>
         </template>
 
         <v-col cols="12" sm="6">
-          <v-text-field
-              v-model.number="pref!.memory_working_set_limit"
-              type="number"
-              hide-details
-              suffix="MiB"
-              :label="t('settings.advanced.qbittorrent.allocatedRam')" />
+          <v-text-field v-model.number="pref!.memory_working_set_limit" type="number" hide-details suffix="MiB" :label="t('settings.advanced.qbittorrent.allocatedRam')" />
         </v-col>
         <v-col cols="12" sm="6">
           <v-text-field v-model.number="torrentFileSizeLimit" type="number" hide-details suffix="MiB" :label="t('settings.advanced.qbittorrent.torrentFileSizeLimit')" />
@@ -156,12 +143,7 @@ onBeforeMount(async () => {
           <v-checkbox v-model="pref!.recheck_completed_torrents" hide-details :label="t('settings.advanced.qbittorrent.recheckOnCompletion')" />
         </v-col>
         <v-col cols="12" sm="6">
-          <v-text-field
-              v-model.number="pref!.refresh_interval"
-              type="number"
-              hide-details
-              suffix="ms"
-              :label="t('settings.advanced.qbittorrent.refreshInterval')" />
+          <v-text-field v-model.number="pref!.refresh_interval" type="number" hide-details suffix="ms" :label="t('settings.advanced.qbittorrent.refreshInterval')" />
         </v-col>
 
         <v-col cols="12" sm="6">
@@ -180,17 +162,13 @@ onBeforeMount(async () => {
       <v-row>
         <v-col cols="12" sm="6">
           <v-select
-              v-model="pref!.current_network_interface"
-              hide-details
-              :items="networkInterfaceOptions"
-              :label="t('settings.advanced.qbittorrent.networking.networkInterfaces.label')" />
+            v-model="pref!.current_network_interface"
+            hide-details
+            :items="networkInterfaceOptions"
+            :label="t('settings.advanced.qbittorrent.networking.networkInterfaces.label')" />
         </v-col>
         <v-col cols="12" sm="6">
-          <v-select
-              v-model="pref!.current_interface_address"
-              hide-details
-              :items="ipAddressesOptions"
-              :label="t('settings.advanced.qbittorrent.networking.ipAddress.label')" />
+          <v-select v-model="pref!.current_interface_address" hide-details :items="ipAddressesOptions" :label="t('settings.advanced.qbittorrent.networking.ipAddress.label')" />
         </v-col>
       </v-row>
     </v-list-item>
@@ -205,17 +183,14 @@ onBeforeMount(async () => {
         </v-col>
         <v-col cols="12" class="py-0">
           <v-text-field
-              v-model.number="pref!.embedded_tracker_port"
-              :disabled="!pref!.enable_embedded_tracker"
-              type="number"
-              hide-details
-              :label="t('settings.advanced.qbittorrent.embeddedTracker.port')" />
+            v-model.number="pref!.embedded_tracker_port"
+            :disabled="!pref!.enable_embedded_tracker"
+            type="number"
+            hide-details
+            :label="t('settings.advanced.qbittorrent.embeddedTracker.port')" />
         </v-col>
         <v-col cols="12" class="pt-0">
-          <v-checkbox
-              v-model="pref!.embedded_tracker_port_forwarding"
-              hide-details
-              :label="t('settings.advanced.qbittorrent.embeddedTracker.portForward')" />
+          <v-checkbox v-model="pref!.embedded_tracker_port_forwarding" hide-details :label="t('settings.advanced.qbittorrent.embeddedTracker.portForward')" />
         </v-col>
       </v-row>
     </v-list-item>
@@ -225,17 +200,19 @@ onBeforeMount(async () => {
       <v-list-item>
         <v-row>
           <v-col cols="12" class="pb-0">
-            <v-checkbox v-model="pref!.mark_of_the_web"
-                        hide-details
-                        :label="t('settings.advanced.qbittorrent.enableMarkOfTheWeb')"
-                        :hint="t('settings.advanced.qbittorrent.enableMarkOfTheWebHint')" />
+            <v-checkbox
+              v-model="pref!.mark_of_the_web"
+              hide-details
+              :label="t('settings.advanced.qbittorrent.enableMarkOfTheWeb')"
+              :hint="t('settings.advanced.qbittorrent.enableMarkOfTheWebHint')" />
           </v-col>
 
           <v-col cols="12" class="pt-0">
-            <v-text-field v-model="pref!.python_executable_path"
-                          hide-details
-                          :label="t('settings.advanced.qbittorrent.pythonExecutablePath')"
-                          :hint="t('settings.advanced.qbittorrent.pythonExecutablePathHint')"/>
+            <v-text-field
+              v-model="pref!.python_executable_path"
+              hide-details
+              :label="t('settings.advanced.qbittorrent.pythonExecutablePath')"
+              :hint="t('settings.advanced.qbittorrent.pythonExecutablePathHint')" />
           </v-col>
         </v-row>
       </v-list-item>
@@ -256,30 +233,17 @@ onBeforeMount(async () => {
     <v-list-item>
       <v-row>
         <v-col cols="12" sm="6">
-          <v-text-field
-              v-model.number="pref!.async_io_threads"
-              type="number"
-              hide-details
-              :label="t('settings.advanced.libtorrent.threads.asyncIoThreads')" />
+          <v-text-field v-model.number="pref!.async_io_threads" type="number" hide-details :label="t('settings.advanced.libtorrent.threads.asyncIoThreads')" />
         </v-col>
         <v-col cols="12" sm="6">
-          <v-text-field
-              v-model.number="pref!.hashing_threads"
-              type="number"
-              hide-details
-              :label="t('settings.advanced.libtorrent.threads.hashingThreads')" />
+          <v-text-field v-model.number="pref!.hashing_threads" type="number" hide-details :label="t('settings.advanced.libtorrent.threads.hashingThreads')" />
         </v-col>
 
         <v-col cols="12" sm="6">
           <v-text-field v-model.number="pref!.file_pool_size" type="number" hide-details :label="t('settings.advanced.libtorrent.threads.filePoolSize')" />
         </v-col>
         <v-col cols="12" sm="6">
-          <v-text-field
-              v-model.number="pref!.checking_memory_use"
-              type="number"
-              hide-details
-              suffix="MiB"
-              :label="t('settings.advanced.libtorrent.threads.outstandingMemory')" />
+          <v-text-field v-model.number="pref!.checking_memory_use" type="number" hide-details suffix="MiB" :label="t('settings.advanced.libtorrent.threads.outstandingMemory')" />
         </v-col>
       </v-row>
     </v-list-item>
@@ -290,47 +254,29 @@ onBeforeMount(async () => {
     <v-list-item>
       <v-row>
         <v-col cols="12" sm="6">
-          <v-text-field
-              v-model.number="pref!.disk_cache"
-              type="number"
-              hide-details
-              suffix="MiB"
-              :label="t('settings.advanced.libtorrent.disk.diskCache')" />
+          <v-text-field v-model.number="pref!.disk_cache" type="number" hide-details suffix="MiB" :label="t('settings.advanced.libtorrent.disk.diskCache')" />
         </v-col>
         <v-col cols="12" sm="6">
           <v-text-field
-              v-model.number="pref!.disk_cache_ttl"
-              type="number"
-              hide-details
-              :suffix="t('units.seconds', pref!.disk_cache_ttl)"
-              :label="t('settings.advanced.libtorrent.disk.diskCacheExpiry')" />
+            v-model.number="pref!.disk_cache_ttl"
+            type="number"
+            hide-details
+            :suffix="t('units.seconds', pref!.disk_cache_ttl)"
+            :label="t('settings.advanced.libtorrent.disk.diskCacheExpiry')" />
         </v-col>
 
         <v-col cols="12">
-          <v-text-field
-              v-model.number="pref!.disk_queue_size"
-              type="number"
-              hide-details
-              suffix="kiB"
-              :label="t('settings.advanced.libtorrent.disk.diskQueueSize')" />
+          <v-text-field v-model.number="pref!.disk_queue_size" type="number" hide-details suffix="kiB" :label="t('settings.advanced.libtorrent.disk.diskQueueSize')" />
         </v-col>
 
         <v-col cols="12" sm="4">
           <v-select v-model="pref!.disk_io_type" hide-details :items="diskIoTypeOptions" :label="t('settings.advanced.libtorrent.disk.diskIoType')" />
         </v-col>
         <v-col cols="12" sm="4">
-          <v-select
-              v-model="pref!.disk_io_read_mode"
-              hide-details
-              :items="diskIoModeReadOptions"
-              :label="t('settings.advanced.libtorrent.disk.diskIoReadMode')" />
+          <v-select v-model="pref!.disk_io_read_mode" hide-details :items="diskIoModeReadOptions" :label="t('settings.advanced.libtorrent.disk.diskIoReadMode')" />
         </v-col>
         <v-col cols="12" sm="4">
-          <v-select
-              v-model="pref!.disk_io_write_mode"
-              hide-details
-              :items="diskIoModeWriteOptions"
-              :label="t('settings.advanced.libtorrent.disk.diskIoWriteMode')" />
+          <v-select v-model="pref!.disk_io_write_mode" hide-details :items="diskIoModeWriteOptions" :label="t('settings.advanced.libtorrent.disk.diskIoWriteMode')" />
         </v-col>
       </v-row>
     </v-list-item>
@@ -340,18 +286,10 @@ onBeforeMount(async () => {
     <v-list-item>
       <v-row>
         <v-col cols="12" sm="6">
-          <v-text-field
-              v-model.number="pref!.bdecode_depth_limit"
-              type="number"
-              hide-details
-              :label="t('settings.advanced.libtorrent.threads.bdecodeDepthLimit')" />
+          <v-text-field v-model.number="pref!.bdecode_depth_limit" type="number" hide-details :label="t('settings.advanced.libtorrent.threads.bdecodeDepthLimit')" />
         </v-col>
         <v-col cols="12" sm="6">
-          <v-text-field
-              v-model.number="pref!.bdecode_token_limit"
-              type="number"
-              hide-details
-              :label="t('settings.advanced.libtorrent.threads.bdecodeTokenLimit')" />
+          <v-text-field v-model.number="pref!.bdecode_token_limit" type="number" hide-details :label="t('settings.advanced.libtorrent.threads.bdecodeTokenLimit')" />
         </v-col>
 
         <v-col cols="12" sm="4">
@@ -365,53 +303,44 @@ onBeforeMount(async () => {
         </v-col>
 
         <v-col cols="12" sm="4">
-          <v-text-field
-              v-model.number="pref!.send_buffer_watermark"
-              type="number"
-              hide-details
-              suffix="kiB"
-              :label="t('settings.advanced.libtorrent.sendBufferWatermark')" />
+          <v-text-field v-model.number="pref!.send_buffer_watermark" type="number" hide-details suffix="kiB" :label="t('settings.advanced.libtorrent.sendBufferWatermark')" />
         </v-col>
         <v-col cols="12" sm="4">
           <v-text-field
-              v-model.number="pref!.send_buffer_low_watermark"
-              type="number"
-              hide-details
-              suffix="kiB"
-              :label="t('settings.advanced.libtorrent.sendBufferLowWatermark')" />
+            v-model.number="pref!.send_buffer_low_watermark"
+            type="number"
+            hide-details
+            suffix="kiB"
+            :label="t('settings.advanced.libtorrent.sendBufferLowWatermark')" />
         </v-col>
         <v-col cols="12" sm="4">
           <v-text-field
-              v-model.number="pref!.send_buffer_watermark_factor"
-              type="number"
-              hide-details
-              suffix="%"
-              :label="t('settings.advanced.libtorrent.sendBufferWatermarkFactor')" />
+            v-model.number="pref!.send_buffer_watermark_factor"
+            type="number"
+            hide-details
+            suffix="%"
+            :label="t('settings.advanced.libtorrent.sendBufferWatermarkFactor')" />
         </v-col>
 
         <v-col cols="12">
-          <v-text-field
-              v-model.number="pref!.connection_speed"
-              type="number"
-              hide-details
-              :label="t('settings.advanced.libtorrent.outgoingConnectionsPerSecond')" />
+          <v-text-field v-model.number="pref!.connection_speed" type="number" hide-details :label="t('settings.advanced.libtorrent.outgoingConnectionsPerSecond')" />
         </v-col>
 
         <v-col cols="12" sm="4">
           <v-text-field
-              v-model.number="pref!.socket_send_buffer_size"
-              type="number"
-              :label="t('settings.advanced.libtorrent.socketSendBufferSize')"
-              :hint="t('settings.advanced.libtorrent.socketSendBufferSizeHint')"
-              suffix="kiB" />
+            v-model.number="pref!.socket_send_buffer_size"
+            type="number"
+            :label="t('settings.advanced.libtorrent.socketSendBufferSize')"
+            :hint="t('settings.advanced.libtorrent.socketSendBufferSizeHint')"
+            suffix="kiB" />
         </v-col>
         <v-col cols="12" sm="4">
           <v-text-field
-              v-model.number="pref!.socket_receive_buffer_size"
-              type="number"
-              :label="t('settings.advanced.libtorrent.socketReceiveBufferSize')"
-              :hint="t('settings.advanced.libtorrent.socketReceiveBufferSizeHint')"
-              suffix="kiB" />
+            v-model.number="pref!.socket_receive_buffer_size"
+            type="number"
+            :label="t('settings.advanced.libtorrent.socketReceiveBufferSize')"
+            :hint="t('settings.advanced.libtorrent.socketReceiveBufferSizeHint')"
+            suffix="kiB" />
         </v-col>
         <v-col cols="12" sm="4">
           <v-text-field v-model.number="pref!.socket_backlog_size" type="number" hide-details :label="t('settings.advanced.libtorrent.socketBacklogSize')" />
@@ -425,26 +354,14 @@ onBeforeMount(async () => {
     <v-list-item>
       <v-row>
         <v-col cols="12" sm="6">
-          <v-text-field
-              v-model.number="pref!.outgoing_ports_min"
-              type="number"
-              hide-details
-              :label="t('settings.advanced.libtorrent.networking.outgoingPortsMin')" />
+          <v-text-field v-model.number="pref!.outgoing_ports_min" type="number" hide-details :label="t('settings.advanced.libtorrent.networking.outgoingPortsMin')" />
         </v-col>
         <v-col cols="12" sm="6">
-          <v-text-field
-              v-model.number="pref!.outgoing_ports_max"
-              type="number"
-              hide-details
-              :label="t('settings.advanced.libtorrent.networking.outgoingPortsMax')" />
+          <v-text-field v-model.number="pref!.outgoing_ports_max" type="number" hide-details :label="t('settings.advanced.libtorrent.networking.outgoingPortsMax')" />
         </v-col>
 
         <v-col cols="12" sm="6">
-          <v-text-field
-              v-model.number="pref!.upnp_lease_duration"
-              type="number"
-              hide-details
-              :label="t('settings.advanced.libtorrent.networking.upnpLeaseDuration')" />
+          <v-text-field v-model.number="pref!.upnp_lease_duration" type="number" hide-details :label="t('settings.advanced.libtorrent.networking.upnpLeaseDuration')" />
         </v-col>
         <v-col cols="12" sm="6">
           <v-text-field v-model.number="pref!.peer_tos" type="number" hide-details :label="t('settings.advanced.libtorrent.networking.peerTos')" />
@@ -452,10 +369,10 @@ onBeforeMount(async () => {
 
         <v-col cols="12">
           <v-select
-              v-model="pref!.utp_tcp_mixed_mode"
-              hide-details
-              :items="utpTcpMixedModeOptions"
-              :label="t('settings.advanced.libtorrent.networking.utpTcpMixedModeAlgorithm')" />
+            v-model="pref!.utp_tcp_mixed_mode"
+            hide-details
+            :items="utpTcpMixedModeOptions"
+            :label="t('settings.advanced.libtorrent.networking.utpTcpMixedModeAlgorithm')" />
         </v-col>
       </v-row>
     </v-list-item>
@@ -470,25 +387,19 @@ onBeforeMount(async () => {
         </v-col>
         <v-col cols="12" sm="6">
           <v-checkbox
-              v-model="pref!.enable_multi_connections_from_same_ip"
-              hide-details
-              :label="t('settings.advanced.libtorrent.security.allowMultipleConnectionsFromTheSameIPAddress')" />
+            v-model="pref!.enable_multi_connections_from_same_ip"
+            hide-details
+            :label="t('settings.advanced.libtorrent.security.allowMultipleConnectionsFromTheSameIPAddress')" />
         </v-col>
 
         <v-col cols="12" sm="4">
-          <v-checkbox
-              v-model="pref!.validate_https_tracker_certificate"
-              hide-details
-              :label="t('settings.advanced.libtorrent.security.validateHTTPSTrackerCertificate')" />
+          <v-checkbox v-model="pref!.validate_https_tracker_certificate" hide-details :label="t('settings.advanced.libtorrent.security.validateHTTPSTrackerCertificate')" />
         </v-col>
         <v-col cols="12" sm="4">
           <v-checkbox v-model="pref!.ssrf_mitigation" hide-details :label="t('settings.advanced.libtorrent.security.mitigateSSRF')" />
         </v-col>
         <v-col cols="12" sm="4">
-          <v-checkbox
-              v-model="pref!.block_peers_on_privileged_ports"
-              hide-details
-              :label="t('settings.advanced.libtorrent.security.blockPeersOnPrivilegedPorts')" />
+          <v-checkbox v-model="pref!.block_peers_on_privileged_ports" hide-details :label="t('settings.advanced.libtorrent.security.blockPeersOnPrivilegedPorts')" />
         </v-col>
       </v-row>
     </v-list-item>
@@ -498,18 +409,14 @@ onBeforeMount(async () => {
     <v-list-item>
       <v-row>
         <v-col cols="12" sm="6">
-          <v-select
-              v-model="pref!.upload_slots_behavior"
-              hide-details
-              :items="uploadSlotsBehaviorOptions"
-              :label="t('settings.advanced.libtorrent.uploadSlotsBehavior')" />
+          <v-select v-model="pref!.upload_slots_behavior" hide-details :items="uploadSlotsBehaviorOptions" :label="t('settings.advanced.libtorrent.uploadSlotsBehavior')" />
         </v-col>
         <v-col cols="12" sm="6">
           <v-select
-              v-model="pref!.upload_choking_algorithm"
-              hide-details
-              :items="uploadChokingAlgorithmOptions"
-              :label="t('settings.advanced.libtorrent.uploadChokingAlgorithm')" />
+            v-model="pref!.upload_choking_algorithm"
+            hide-details
+            :items="uploadChokingAlgorithmOptions"
+            :label="t('settings.advanced.libtorrent.uploadChokingAlgorithm')" />
         </v-col>
 
         <v-col cols="12" sm="6">
@@ -524,38 +431,25 @@ onBeforeMount(async () => {
         </v-col>
 
         <v-col cols="12" sm="6">
-          <v-text-field
-              v-model.number="pref!.max_concurrent_http_announces"
-              type="number"
-              hide-details
-              :label="t('settings.advanced.libtorrent.maxConcurrentHTTPAnnounces')" />
+          <v-text-field v-model.number="pref!.max_concurrent_http_announces" type="number" hide-details :label="t('settings.advanced.libtorrent.maxConcurrentHTTPAnnounces')" />
         </v-col>
         <v-col cols="12" sm="6">
-          <v-text-field
-              v-model.number="pref!.stop_tracker_timeout"
-              type="number"
-              hide-details
-              :label="t('settings.advanced.libtorrent.stopTrackerTimeout')" />
+          <v-text-field v-model.number="pref!.stop_tracker_timeout" type="number" hide-details :label="t('settings.advanced.libtorrent.stopTrackerTimeout')" />
         </v-col>
 
         <v-col cols="12" sm="4">
           <v-text-field v-model.number="pref!.peer_turnover" type="number" hide-details suffix="%" :label="t('settings.advanced.libtorrent.peerTurnover')" />
         </v-col>
         <v-col cols="12" sm="4">
-          <v-text-field
-              v-model.number="pref!.peer_turnover_cutoff"
-              type="number"
-              hide-details
-              suffix="%"
-              :label="t('settings.advanced.libtorrent.peerTurnoverCutoff')" />
+          <v-text-field v-model.number="pref!.peer_turnover_cutoff" type="number" hide-details suffix="%" :label="t('settings.advanced.libtorrent.peerTurnoverCutoff')" />
         </v-col>
         <v-col cols="12" sm="4">
           <v-text-field
-              v-model.number="pref!.peer_turnover_interval"
-              type="number"
-              hide-details
-              :suffix="t('units.seconds', pref!.peer_turnover_interval)"
-              :label="t('settings.advanced.libtorrent.peerTurnoverInterval')" />
+            v-model.number="pref!.peer_turnover_interval"
+            type="number"
+            hide-details
+            :suffix="t('units.seconds', pref!.peer_turnover_interval)"
+            :label="t('settings.advanced.libtorrent.peerTurnoverInterval')" />
         </v-col>
 
         <v-col cols="12">
@@ -563,9 +457,10 @@ onBeforeMount(async () => {
         </v-col>
 
         <v-col cols="12">
-          <v-text-field v-model="pref!.dht_bootstrap_nodes"
-                        :label="t('settings.advanced.libtorrent.dhtBootstrapNodes')"
-                        :hint="t('settings.advanced.libtorrent.dhtBootstrapNodesHint')" />
+          <v-text-field
+            v-model="pref!.dht_bootstrap_nodes"
+            :label="t('settings.advanced.libtorrent.dhtBootstrapNodes')"
+            :hint="t('settings.advanced.libtorrent.dhtBootstrapNodesHint')" />
         </v-col>
       </v-row>
     </v-list-item>
@@ -580,10 +475,22 @@ onBeforeMount(async () => {
           </v-col>
 
           <v-col cols="12">
-            <v-text-field v-model="pref!.i2p_inbound_quantity" :rules="i2pQuantityRules" type="number" min="1" max="16" :label="t('settings.advanced.libtorrent.i2p.inboundQuantity')" />
+            <v-text-field
+              v-model="pref!.i2p_inbound_quantity"
+              :rules="i2pQuantityRules"
+              type="number"
+              min="1"
+              max="16"
+              :label="t('settings.advanced.libtorrent.i2p.inboundQuantity')" />
           </v-col>
           <v-col cols="12">
-            <v-text-field v-model="pref!.i2p_outbound_quantity" :rules="i2pQuantityRules" type="number" min="1" max="16" :label="t('settings.advanced.libtorrent.i2p.outboundQuantity')" />
+            <v-text-field
+              v-model="pref!.i2p_outbound_quantity"
+              :rules="i2pQuantityRules"
+              type="number"
+              min="1"
+              max="16"
+              :label="t('settings.advanced.libtorrent.i2p.outboundQuantity')" />
           </v-col>
           <v-col cols="12">
             <v-text-field v-model="pref!.i2p_inbound_length" :rules="i2pLengthRules" type="number" min="0" max="7" :label="t('settings.advanced.libtorrent.i2p.inboundLength')" />
@@ -600,7 +507,14 @@ onBeforeMount(async () => {
             <v-checkbox v-model="pref!.ssl_enabled" hide-details :label="t('settings.advanced.libtorrent.ssl.enabled')" />
           </v-col>
           <v-col cols="12" class="pt-0">
-            <v-text-field v-model="pref!.ssl_listen_port" :rules="sslRules" type="number" min="0" max="65535" :label="t('settings.advanced.libtorrent.ssl.listenPort')" :hint="t('settings.advanced.libtorrent.ssl.listenPortHint')" />
+            <v-text-field
+              v-model="pref!.ssl_listen_port"
+              :rules="sslRules"
+              type="number"
+              min="0"
+              max="65535"
+              :label="t('settings.advanced.libtorrent.ssl.listenPort')"
+              :hint="t('settings.advanced.libtorrent.ssl.listenPortHint')" />
           </v-col>
         </v-row>
       </v-list-item>

--- a/src/components/Settings/Advanced.vue
+++ b/src/components/Settings/Advanced.vue
@@ -199,10 +199,11 @@ onBeforeMount(async () => {
       <v-divider class="mx-10" />
       <v-list-item>
         <v-row>
-          <v-col cols="12" class="pb-0">
+          <v-col cols="12">
             <v-checkbox
               v-model="pref!.mark_of_the_web"
-              hide-details
+              density="compact"
+              persistent-hint
               :label="t('settings.advanced.qbittorrent.enableMarkOfTheWeb')"
               :hint="t('settings.advanced.qbittorrent.enableMarkOfTheWebHint')" />
           </v-col>

--- a/src/components/Settings/Advanced.vue
+++ b/src/components/Settings/Advanced.vue
@@ -65,6 +65,18 @@ const uploadChokingAlgorithmOptions = [
   { title: t('constants.uploadChokingAlgorithm.antiLeech'), value: UploadChokingAlgorithm.ANTI_LEECH }
 ]
 
+const i2pQuantityRules = [
+  (v: number) => v >= 1 && v <= 16 || t('settings.advanced.libtorrent.i2p.invalidQuantity')
+]
+
+const i2pLengthRules = [
+  (v: number) => v >= 0 && v <= 7 || t('settings.advanced.libtorrent.i2p.invalidLength')
+]
+
+const sslRules = [
+  (v: number) => v >= 0 && v <= 65535 || t('settings.advanced.libtorrent.ssl.rule')
+]
+
 const torrentFileSizeLimit = computed({
   get: () => pref.value!.torrent_file_size_limit / 1024 / 1024,
   set: (value: number) => {
@@ -124,7 +136,7 @@ onBeforeMount(async () => {
           <v-col cols="12">
             <v-text-field v-model="pref!.app_instance_name"
                           hide-details
-                          :label="t('settings.Advanced.qbittorrent.appInstanceName')" />
+                          :label="t('settings.advanced.qbittorrent.appInstanceName')" />
           </v-col>
         </template>
 
@@ -209,17 +221,17 @@ onBeforeMount(async () => {
     </v-list-item>
 
     <template v-if="appStore.version >= '5.0.0'">
-      <v-divider class="mx-10 mt-3" />
+      <v-divider class="mx-10" />
       <v-list-item>
         <v-row>
-          <v-col cols="12">
+          <v-col cols="12" class="pb-0">
             <v-checkbox v-model="pref!.mark_of_the_web"
                         hide-details
                         :label="t('settings.advanced.qbittorrent.enableMarkOfTheWeb')"
                         :hint="t('settings.advanced.qbittorrent.enableMarkOfTheWebHint')" />
           </v-col>
 
-          <v-col cols="12">
+          <v-col cols="12" class="pt-0">
             <v-text-field v-model="pref!.python_executable_path"
                           hide-details
                           :label="t('settings.advanced.qbittorrent.pythonExecutablePath')"
@@ -229,7 +241,7 @@ onBeforeMount(async () => {
       </v-list-item>
     </template>
 
-    <v-divider />
+    <v-divider class="mt-3" />
 
     <v-list-subheader>
       {{ t('settings.advanced.libtorrent.subheader') }} (
@@ -558,7 +570,9 @@ onBeforeMount(async () => {
       </v-row>
     </v-list-item>
 
-    <template  v-if="appStore.version >= '5.0.0'">
+    <template v-if="appStore.version >= '5.0.0'">
+      <v-divider class="mb-3" />
+
       <v-list-item>
         <v-row>
           <v-col cols="12">
@@ -566,25 +580,27 @@ onBeforeMount(async () => {
           </v-col>
 
           <v-col cols="12">
-            <v-text-field v-model="pref!.i2p_inbound_quantity" type="number" min="1" max="16" hide-details :label="t('settings.advanced.libtorrent.i2p.inboundQuantity')" />
+            <v-text-field v-model="pref!.i2p_inbound_quantity" :rules="i2pQuantityRules" type="number" min="1" max="16" :label="t('settings.advanced.libtorrent.i2p.inboundQuantity')" />
           </v-col>
           <v-col cols="12">
-            <v-text-field v-model="pref!.i2p_outbound_quantity" type="number" min="1" max="16" hide-details :label="t('settings.advanced.libtorrent.i2p.outboundQuantity')" />
+            <v-text-field v-model="pref!.i2p_outbound_quantity" :rules="i2pQuantityRules" type="number" min="1" max="16" :label="t('settings.advanced.libtorrent.i2p.outboundQuantity')" />
           </v-col>
           <v-col cols="12">
-            <v-text-field v-model="pref!.i2p_inbound_length" type="number" min="0" max="7" hide-details :label="t('settings.advanced.libtorrent.i2p.inboundLength')" />
+            <v-text-field v-model="pref!.i2p_inbound_length" :rules="i2pLengthRules" type="number" min="0" max="7" :label="t('settings.advanced.libtorrent.i2p.inboundLength')" />
           </v-col>
           <v-col cols="12">
-            <v-text-field v-model="pref!.i2p_outbound_length" type="number" min="0" max="7" hide-details :label="t('settings.advanced.libtorrent.i2p.outboundLength')" />
+            <v-text-field v-model="pref!.i2p_outbound_length" :rules="i2pLengthRules" type="number" min="0" max="7" :label="t('settings.advanced.libtorrent.i2p.outboundLength')" />
           </v-col>
         </v-row>
 
+        <v-divider class="mt-5" thickness="3" />
+
         <v-row>
-          <v-col cols="12">
+          <v-col cols="12" class="pb-0">
             <v-checkbox v-model="pref!.ssl_enabled" hide-details :label="t('settings.advanced.libtorrent.ssl.enabled')" />
           </v-col>
-          <v-col cols="12">
-            <v-text-field v-model="pref!.ssl_listen_port" type="number" min="0" max="65535" hide-details :label="t('settings.advanced.libtorrent.ssl.listenPort')" :hint="t('settings.advanced.libtorrent.ssl.listenPortHint')" />
+          <v-col cols="12" class="pt-0">
+            <v-text-field v-model="pref!.ssl_listen_port" :rules="sslRules" type="number" min="0" max="65535" :label="t('settings.advanced.libtorrent.ssl.listenPort')" :hint="t('settings.advanced.libtorrent.ssl.listenPortHint')" />
           </v-col>
         </v-row>
       </v-list-item>

--- a/src/components/Settings/Connection.vue
+++ b/src/components/Settings/Connection.vue
@@ -80,13 +80,16 @@ watch(
       <v-row>
         <v-col cols="12" sm="6">
           <v-text-field
-            v-model.number="preferenceStore.preferences!.listen_port"
-            type="number"
-            hide-details
-            :label="t('settings.connection.listeningPort.incomingConnectionPort')" />
+              v-model.number="preferenceStore.preferences!.listen_port"
+              type="number"
+              hide-details
+              :label="t('settings.connection.listeningPort.incomingConnectionPort')" />
         </v-col>
         <v-col cols="12" sm="6" class="d-flex align-center justify-center">
-          <v-btn color="primary" @click="generateRandomPort">{{ t('settings.connection.listeningPort.randomPort') }} </v-btn>
+          <v-btn color="primary" @click="generateRandomPort">{{
+              t('settings.connection.listeningPort.randomPort')
+            }}
+          </v-btn>
         </v-col>
       </v-row>
     </v-list-item>
@@ -104,48 +107,85 @@ watch(
           <div class="d-flex align-center">
             <span><v-checkbox-btn v-model="max_conn_enabled" /></span>
             <v-text-field
-              v-model.number="preferenceStore.preferences!.max_connec"
-              :disabled="!max_conn_enabled"
-              type="number"
-              hide-details
-              :label="t('settings.connection.connectionLimits.globalMaxConnection')" />
+                v-model.number="preferenceStore.preferences!.max_connec"
+                :disabled="!max_conn_enabled"
+                type="number"
+                hide-details
+                :label="t('settings.connection.connectionLimits.globalMaxConnection')" />
           </div>
         </v-col>
         <v-col cols="12" sm="6">
           <div class="d-flex align-center">
             <span><v-checkbox-btn v-model="max_conn_per_torrent_enabled" /></span>
             <v-text-field
-              v-model.number="preferenceStore.preferences!.max_connec_per_torrent"
-              :disabled="!max_conn_per_torrent_enabled"
-              type="number"
-              hide-details
-              :label="t('settings.connection.connectionLimits.perTorrentMaxConnection')" />
+                v-model.number="preferenceStore.preferences!.max_connec_per_torrent"
+                :disabled="!max_conn_per_torrent_enabled"
+                type="number"
+                hide-details
+                :label="t('settings.connection.connectionLimits.perTorrentMaxConnection')" />
           </div>
         </v-col>
         <v-col cols="12" sm="6">
           <div class="d-flex align-center">
             <span><v-checkbox-btn v-model="max_uploads_enabled" /></span>
             <v-text-field
-              v-model.number="preferenceStore.preferences!.max_uploads"
-              :disabled="!max_uploads_enabled"
-              type="number"
-              hide-details
-              :label="t('settings.connection.connectionLimits.globalMaxUploadSlots')" />
+                v-model.number="preferenceStore.preferences!.max_uploads"
+                :disabled="!max_uploads_enabled"
+                type="number"
+                hide-details
+                :label="t('settings.connection.connectionLimits.globalMaxUploadSlots')" />
           </div>
         </v-col>
         <v-col cols="12" sm="6">
           <div class="d-flex align-center">
             <span><v-checkbox-btn v-model="max_uploads_per_torrent_enabled" /></span>
             <v-text-field
-              v-model.number="preferenceStore.preferences!.max_uploads_per_torrent"
-              :disabled="!max_uploads_per_torrent_enabled"
-              type="number"
-              hide-details
-              :label="t('settings.connection.connectionLimits.perTorrentMaxUploadSlots')" />
+                v-model.number="preferenceStore.preferences!.max_uploads_per_torrent"
+                :disabled="!max_uploads_per_torrent_enabled"
+                type="number"
+                hide-details
+                :label="t('settings.connection.connectionLimits.perTorrentMaxUploadSlots')" />
           </div>
         </v-col>
       </v-row>
     </v-list-item>
+
+    <template v-if="appStore.version >= '5.0.0'">
+      <v-divider class="mt-3" />
+      <v-list-subheader>{{ t('settings.connection.i2p.subheader') }}</v-list-subheader>
+
+      <v-list-item>
+        <v-row>
+          <v-col cols="12">
+            <v-checkbox v-model="preferenceStore.preferences!.i2p_enabled" hide-details :label="t('settings.connection.i2p.enabled')" />
+          </v-col>
+
+          <v-col cols="12" md="6">
+            <v-text-field v-model="preferenceStore.preferences!.i2p_address"
+                          :disabled="preferenceStore.preferences!.i2p_enabled"
+                          hide-details
+                          :label="t('settings.connection.i2p.address')" />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-text-field v-model="preferenceStore.preferences!.i2p_port"
+                          :disabled="preferenceStore.preferences!.i2p_enabled"
+                          hide-details
+                          :label="t('settings.connection.i2p.port')" />
+          </v-col>
+
+          <v-col cols="12">
+            <v-checkbox v-model="preferenceStore.preferences!.i2p_mixed_mode"
+                        :disabled="preferenceStore.preferences!.i2p_enabled"
+                        hide-details
+                        :label="t('settings.connection.i2p.mixedMode')" />
+          </v-col>
+
+          <v-col cols="12">
+            <h5 class="text-warning font-italic">{{ t('settings.connection.i2p.disclaimer') }}</h5>
+          </v-col>
+        </v-row>
+      </v-list-item>
+    </template>
 
     <v-divider class="mt-3" />
     <v-list-subheader>{{ t('settings.connection.proxy.subheader') }}</v-list-subheader>
@@ -160,11 +200,11 @@ watch(
         </v-col>
         <v-col cols="6" md="4">
           <v-text-field
-            v-model.number="preferenceStore.preferences!.proxy_port"
-            :disabled="isProxyDisabled"
-            type="number"
-            hide-details
-            :label="t('settings.connection.proxy.port')" />
+              v-model.number="preferenceStore.preferences!.proxy_port"
+              :disabled="isProxyDisabled"
+              type="number"
+              hide-details
+              :label="t('settings.connection.proxy.port')" />
         </v-col>
       </v-row>
     </v-list-item>
@@ -176,10 +216,10 @@ watch(
         </v-col>
         <v-col cols="12" sm="6" md="3">
           <v-checkbox
-            v-model="preferenceStore.preferences!.proxy_peer_connections"
-            :disabled="isProxyDisabled || !preferenceStore.preferences!.proxy_bittorrent"
-            hide-details
-            :label="t('settings.connection.proxy.peerConnections')" />
+              v-model="preferenceStore.preferences!.proxy_peer_connections"
+              :disabled="isProxyDisabled || !preferenceStore.preferences!.proxy_bittorrent"
+              hide-details
+              :label="t('settings.connection.proxy.peerConnections')" />
         </v-col>
         <v-col cols="12" sm="6" md="3">
           <v-checkbox v-model="preferenceStore.preferences!.proxy_rss" :disabled="isProxyDisabled || isProxySocks4" hide-details :label="t('settings.connection.proxy.rss')" />
@@ -194,33 +234,33 @@ watch(
       <v-row>
         <v-col cols="12">
           <v-checkbox
-            v-model="preferenceStore.preferences!.proxy_hostname_lookup"
-            :disabled="isProxyDisabled || isProxySocks4"
-            hide-details
-            :label="t('settings.connection.proxy.hostNameLookup')" />
+              v-model="preferenceStore.preferences!.proxy_hostname_lookup"
+              :disabled="isProxyDisabled || isProxySocks4"
+              hide-details
+              :label="t('settings.connection.proxy.hostNameLookup')" />
         </v-col>
 
         <v-col cols="12">
           <v-checkbox
-            v-model="preferenceStore.preferences!.proxy_auth_enabled"
-            :disabled="isProxyDisabled || isProxySocks4"
-            hide-details
-            :label="t('settings.connection.proxy.auth.subtitle')" />
+              v-model="preferenceStore.preferences!.proxy_auth_enabled"
+              :disabled="isProxyDisabled || isProxySocks4"
+              hide-details
+              :label="t('settings.connection.proxy.auth.subtitle')" />
         </v-col>
         <v-col cols="12" sm="6">
           <v-text-field
-            v-model="preferenceStore.preferences!.proxy_username"
-            :disabled="isProxyDisabled || !preferenceStore.preferences!.proxy_auth_enabled"
-            dense
-            hide-details
-            :label="t('settings.connection.proxy.auth.username')" />
+              v-model="preferenceStore.preferences!.proxy_username"
+              :disabled="isProxyDisabled || !preferenceStore.preferences!.proxy_auth_enabled"
+              dense
+              hide-details
+              :label="t('settings.connection.proxy.auth.username')" />
         </v-col>
         <v-col cols="12" sm="6">
           <PasswordField
-            v-model="preferenceStore.preferences!.proxy_password"
-            :hide-icon="isProxyDisabled || !preferenceStore.preferences!.proxy_auth_enabled"
-            :disabled="isProxyDisabled || !preferenceStore.preferences!.proxy_auth_enabled"
-            :label="t('settings.connection.proxy.auth.password')" />
+              v-model="preferenceStore.preferences!.proxy_password"
+              :hide-icon="isProxyDisabled || !preferenceStore.preferences!.proxy_auth_enabled"
+              :disabled="isProxyDisabled || !preferenceStore.preferences!.proxy_auth_enabled"
+              :label="t('settings.connection.proxy.auth.password')" />
         </v-col>
       </v-row>
     </v-list-item>

--- a/src/components/Settings/Connection.vue
+++ b/src/components/Settings/Connection.vue
@@ -28,9 +28,7 @@ const max_conn_per_torrent_enabled = ref(false)
 const max_uploads_enabled = ref(false)
 const max_uploads_per_torrent_enabled = ref(false)
 
-const portRule = [
-  (v: number) => v >= 0 && v <= 65535 || t('settings.connection.i2p.rule')
-]
+const portRule = [(v: number) => (v >= 0 && v <= 65535) || t('settings.connection.i2p.rule')]
 
 const generateRandomPort = () => {
   // source: https://github.com/qbittorrent/qBittorrent/blob/d83b2a61311b0dc3bc31ee52d1b9eaac715c3cdf/src/webui/www/private/views/preferences.html#L1729-L1734
@@ -85,16 +83,13 @@ watch(
       <v-row>
         <v-col cols="12" sm="6">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.listen_port"
-              type="number"
-              hide-details
-              :label="t('settings.connection.listeningPort.incomingConnectionPort')" />
+            v-model.number="preferenceStore.preferences!.listen_port"
+            type="number"
+            hide-details
+            :label="t('settings.connection.listeningPort.incomingConnectionPort')" />
         </v-col>
         <v-col cols="12" sm="6" class="d-flex align-center justify-center">
-          <v-btn color="primary" @click="generateRandomPort">{{
-              t('settings.connection.listeningPort.randomPort')
-            }}
-          </v-btn>
+          <v-btn color="primary" @click="generateRandomPort">{{ t('settings.connection.listeningPort.randomPort') }} </v-btn>
         </v-col>
       </v-row>
     </v-list-item>
@@ -112,44 +107,44 @@ watch(
           <div class="d-flex align-center">
             <span><v-checkbox-btn v-model="max_conn_enabled" /></span>
             <v-text-field
-                v-model.number="preferenceStore.preferences!.max_connec"
-                :disabled="!max_conn_enabled"
-                type="number"
-                hide-details
-                :label="t('settings.connection.connectionLimits.globalMaxConnection')" />
+              v-model.number="preferenceStore.preferences!.max_connec"
+              :disabled="!max_conn_enabled"
+              type="number"
+              hide-details
+              :label="t('settings.connection.connectionLimits.globalMaxConnection')" />
           </div>
         </v-col>
         <v-col cols="12" sm="6">
           <div class="d-flex align-center">
             <span><v-checkbox-btn v-model="max_conn_per_torrent_enabled" /></span>
             <v-text-field
-                v-model.number="preferenceStore.preferences!.max_connec_per_torrent"
-                :disabled="!max_conn_per_torrent_enabled"
-                type="number"
-                hide-details
-                :label="t('settings.connection.connectionLimits.perTorrentMaxConnection')" />
+              v-model.number="preferenceStore.preferences!.max_connec_per_torrent"
+              :disabled="!max_conn_per_torrent_enabled"
+              type="number"
+              hide-details
+              :label="t('settings.connection.connectionLimits.perTorrentMaxConnection')" />
           </div>
         </v-col>
         <v-col cols="12" sm="6">
           <div class="d-flex align-center">
             <span><v-checkbox-btn v-model="max_uploads_enabled" /></span>
             <v-text-field
-                v-model.number="preferenceStore.preferences!.max_uploads"
-                :disabled="!max_uploads_enabled"
-                type="number"
-                hide-details
-                :label="t('settings.connection.connectionLimits.globalMaxUploadSlots')" />
+              v-model.number="preferenceStore.preferences!.max_uploads"
+              :disabled="!max_uploads_enabled"
+              type="number"
+              hide-details
+              :label="t('settings.connection.connectionLimits.globalMaxUploadSlots')" />
           </div>
         </v-col>
         <v-col cols="12" sm="6">
           <div class="d-flex align-center">
             <span><v-checkbox-btn v-model="max_uploads_per_torrent_enabled" /></span>
             <v-text-field
-                v-model.number="preferenceStore.preferences!.max_uploads_per_torrent"
-                :disabled="!max_uploads_per_torrent_enabled"
-                type="number"
-                hide-details
-                :label="t('settings.connection.connectionLimits.perTorrentMaxUploadSlots')" />
+              v-model.number="preferenceStore.preferences!.max_uploads_per_torrent"
+              :disabled="!max_uploads_per_torrent_enabled"
+              type="number"
+              hide-details
+              :label="t('settings.connection.connectionLimits.perTorrentMaxUploadSlots')" />
           </div>
         </v-col>
       </v-row>
@@ -166,26 +161,29 @@ watch(
           </v-col>
 
           <v-col cols="12" md="6" class="py-0">
-            <v-text-field v-model="preferenceStore.preferences!.i2p_address"
-                          :disabled="preferenceStore.preferences!.i2p_enabled"
-                          hide-details
-                          :label="t('settings.connection.i2p.address')" />
+            <v-text-field
+              v-model="preferenceStore.preferences!.i2p_address"
+              :disabled="preferenceStore.preferences!.i2p_enabled"
+              hide-details
+              :label="t('settings.connection.i2p.address')" />
           </v-col>
           <v-col cols="12" md="6" class="py-0">
-            <v-text-field v-model="preferenceStore.preferences!.i2p_port"
-                          :disabled="preferenceStore.preferences!.i2p_enabled"
-                          :rules="portRule"
-                          type="number"
-                          min="0"
-                          max="65535"
-                          :label="t('settings.connection.i2p.port')" />
+            <v-text-field
+              v-model="preferenceStore.preferences!.i2p_port"
+              :disabled="preferenceStore.preferences!.i2p_enabled"
+              :rules="portRule"
+              type="number"
+              min="0"
+              max="65535"
+              :label="t('settings.connection.i2p.port')" />
           </v-col>
 
           <v-col cols="12" class="py-0">
-            <v-checkbox v-model="preferenceStore.preferences!.i2p_mixed_mode"
-                        :disabled="preferenceStore.preferences!.i2p_enabled"
-                        hide-details
-                        :label="t('settings.connection.i2p.mixedMode')" />
+            <v-checkbox
+              v-model="preferenceStore.preferences!.i2p_mixed_mode"
+              :disabled="preferenceStore.preferences!.i2p_enabled"
+              hide-details
+              :label="t('settings.connection.i2p.mixedMode')" />
           </v-col>
 
           <v-col cols="12" class="pt-0">
@@ -208,11 +206,11 @@ watch(
         </v-col>
         <v-col cols="6" md="4">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.proxy_port"
-              :disabled="isProxyDisabled"
-              type="number"
-              hide-details
-              :label="t('settings.connection.proxy.port')" />
+            v-model.number="preferenceStore.preferences!.proxy_port"
+            :disabled="isProxyDisabled"
+            type="number"
+            hide-details
+            :label="t('settings.connection.proxy.port')" />
         </v-col>
       </v-row>
     </v-list-item>
@@ -224,10 +222,10 @@ watch(
         </v-col>
         <v-col cols="12" sm="6" md="3">
           <v-checkbox
-              v-model="preferenceStore.preferences!.proxy_peer_connections"
-              :disabled="isProxyDisabled || !preferenceStore.preferences!.proxy_bittorrent"
-              hide-details
-              :label="t('settings.connection.proxy.peerConnections')" />
+            v-model="preferenceStore.preferences!.proxy_peer_connections"
+            :disabled="isProxyDisabled || !preferenceStore.preferences!.proxy_bittorrent"
+            hide-details
+            :label="t('settings.connection.proxy.peerConnections')" />
         </v-col>
         <v-col cols="12" sm="6" md="3">
           <v-checkbox v-model="preferenceStore.preferences!.proxy_rss" :disabled="isProxyDisabled || isProxySocks4" hide-details :label="t('settings.connection.proxy.rss')" />
@@ -242,33 +240,33 @@ watch(
       <v-row>
         <v-col cols="12">
           <v-checkbox
-              v-model="preferenceStore.preferences!.proxy_hostname_lookup"
-              :disabled="isProxyDisabled || isProxySocks4"
-              hide-details
-              :label="t('settings.connection.proxy.hostNameLookup')" />
+            v-model="preferenceStore.preferences!.proxy_hostname_lookup"
+            :disabled="isProxyDisabled || isProxySocks4"
+            hide-details
+            :label="t('settings.connection.proxy.hostNameLookup')" />
         </v-col>
 
         <v-col cols="12">
           <v-checkbox
-              v-model="preferenceStore.preferences!.proxy_auth_enabled"
-              :disabled="isProxyDisabled || isProxySocks4"
-              hide-details
-              :label="t('settings.connection.proxy.auth.subtitle')" />
+            v-model="preferenceStore.preferences!.proxy_auth_enabled"
+            :disabled="isProxyDisabled || isProxySocks4"
+            hide-details
+            :label="t('settings.connection.proxy.auth.subtitle')" />
         </v-col>
         <v-col cols="12" sm="6">
           <v-text-field
-              v-model="preferenceStore.preferences!.proxy_username"
-              :disabled="isProxyDisabled || !preferenceStore.preferences!.proxy_auth_enabled"
-              dense
-              hide-details
-              :label="t('settings.connection.proxy.auth.username')" />
+            v-model="preferenceStore.preferences!.proxy_username"
+            :disabled="isProxyDisabled || !preferenceStore.preferences!.proxy_auth_enabled"
+            dense
+            hide-details
+            :label="t('settings.connection.proxy.auth.username')" />
         </v-col>
         <v-col cols="12" sm="6">
           <PasswordField
-              v-model="preferenceStore.preferences!.proxy_password"
-              :hide-icon="isProxyDisabled || !preferenceStore.preferences!.proxy_auth_enabled"
-              :disabled="isProxyDisabled || !preferenceStore.preferences!.proxy_auth_enabled"
-              :label="t('settings.connection.proxy.auth.password')" />
+            v-model="preferenceStore.preferences!.proxy_password"
+            :hide-icon="isProxyDisabled || !preferenceStore.preferences!.proxy_auth_enabled"
+            :disabled="isProxyDisabled || !preferenceStore.preferences!.proxy_auth_enabled"
+            :label="t('settings.connection.proxy.auth.password')" />
         </v-col>
       </v-row>
     </v-list-item>

--- a/src/components/Settings/Connection.vue
+++ b/src/components/Settings/Connection.vue
@@ -28,6 +28,10 @@ const max_conn_per_torrent_enabled = ref(false)
 const max_uploads_enabled = ref(false)
 const max_uploads_per_torrent_enabled = ref(false)
 
+const portRule = [
+  (v: number) => v >= 0 && v <= 65535 || t('settings.connection.i2p.rule')
+]
+
 const generateRandomPort = () => {
   // source: https://github.com/qbittorrent/qBittorrent/blob/d83b2a61311b0dc3bc31ee52d1b9eaac715c3cdf/src/webui/www/private/views/preferences.html#L1729-L1734
   const min = 1024
@@ -157,34 +161,34 @@ watch(
 
       <v-list-item>
         <v-row>
-          <v-col cols="12">
+          <v-col cols="12" class="py-0">
             <v-checkbox v-model="preferenceStore.preferences!.i2p_enabled" hide-details :label="t('settings.connection.i2p.enabled')" />
           </v-col>
 
-          <v-col cols="12" md="6">
+          <v-col cols="12" md="6" class="py-0">
             <v-text-field v-model="preferenceStore.preferences!.i2p_address"
                           :disabled="preferenceStore.preferences!.i2p_enabled"
                           hide-details
                           :label="t('settings.connection.i2p.address')" />
           </v-col>
-          <v-col cols="12" md="6">
+          <v-col cols="12" md="6" class="py-0">
             <v-text-field v-model="preferenceStore.preferences!.i2p_port"
                           :disabled="preferenceStore.preferences!.i2p_enabled"
-                          hide-details
+                          :rules="portRule"
                           type="number"
                           min="0"
                           max="65535"
                           :label="t('settings.connection.i2p.port')" />
           </v-col>
 
-          <v-col cols="12">
+          <v-col cols="12" class="py-0">
             <v-checkbox v-model="preferenceStore.preferences!.i2p_mixed_mode"
                         :disabled="preferenceStore.preferences!.i2p_enabled"
                         hide-details
                         :label="t('settings.connection.i2p.mixedMode')" />
           </v-col>
 
-          <v-col cols="12">
+          <v-col cols="12" class="pt-0">
             <h5 class="text-warning font-italic">{{ t('settings.connection.i2p.disclaimer') }}</h5>
           </v-col>
         </v-row>

--- a/src/components/Settings/Connection.vue
+++ b/src/components/Settings/Connection.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import PasswordField from '@/components/Core/PasswordField.vue'
 import { BitTorrentProtocol, ProxyType } from '@/constants/qbit/AppPreferences'
-import { usePreferenceStore } from '@/stores'
+import { useAppStore, usePreferenceStore } from '@/stores'
 import { computed, onBeforeMount, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
+const appStore = useAppStore()
 const preferenceStore = usePreferenceStore()
 
 const proxyTypes = ref([
@@ -170,6 +171,9 @@ watch(
             <v-text-field v-model="preferenceStore.preferences!.i2p_port"
                           :disabled="preferenceStore.preferences!.i2p_enabled"
                           hide-details
+                          type="number"
+                          min="0"
+                          max="65535"
                           :label="t('settings.connection.i2p.port')" />
           </v-col>
 

--- a/src/components/Settings/Downloads.vue
+++ b/src/components/Settings/Downloads.vue
@@ -183,6 +183,11 @@ async function sendTestEmail() {
       <v-checkbox v-model="preferenceStore.preferences!.preallocate_all" hide-details :label="t('settings.downloads.publicSettings.preAllocateDisk')" />
 
       <v-checkbox v-model="preferenceStore.preferences!.incomplete_files_ext" hide-details :label="t('settings.downloads.publicSettings.appendQBExtension')" />
+
+      <v-checkbox v-if="appStore.version >= '5.0.0'"
+                  v-model="preferenceStore.preferences!.use_unwanted_folder"
+                  hide-details
+                  :label="t('settings.downloads.publicSettings.useUnwantedFolder')" />
     </v-list-item>
 
     <v-divider />
@@ -218,6 +223,13 @@ async function sendTestEmail() {
             :items="paramChangedTMMOptions"
             hide-details
             :label="t('settings.downloads.saveManagement.categoryChangedTMM')" />
+        </v-col>
+
+        <v-col cols="12" v-if="appStore.version >= '5.0.0'">
+          <v-checkbox v-model="preferenceStore.preferences!.use_category_paths_in_manual_mode"
+                      hide-details
+                      :label="t('settings.downloads.saveManagement.useCategoryPathInManualMode')"
+          />
         </v-col>
 
         <v-col cols="12">

--- a/src/components/Settings/Downloads.vue
+++ b/src/components/Settings/Downloads.vue
@@ -225,7 +225,7 @@ async function sendTestEmail() {
             :label="t('settings.downloads.saveManagement.categoryChangedTMM')" />
         </v-col>
 
-        <v-col cols="12" v-if="appStore.version >= '5.0.0'">
+        <v-col cols="12" v-if="appStore.version >= '5.0.0'" class="py-0">
           <v-checkbox v-model="preferenceStore.preferences!.use_category_paths_in_manual_mode"
                       hide-details
                       :label="t('settings.downloads.saveManagement.useCategoryPathInManualMode')"
@@ -430,7 +430,7 @@ async function sendTestEmail() {
       <v-btn color="primary" @click="sendTestEmail">{{ t('settings.downloads.mailNotification.test.label') }}</v-btn>
     </v-list-item>
 
-    <v-divider />
+    <v-divider class="mt-3" />
 
     <v-list-subheader>{{ t('settings.downloads.runExternalProgram.subheader') }}</v-list-subheader>
     <v-list-item>

--- a/src/components/Settings/Downloads.vue
+++ b/src/components/Settings/Downloads.vue
@@ -66,7 +66,7 @@ const monitoredFoldersMonitorTypeOptions = ref([
 const addStoppedEnabled = computed({
   get: () => preferenceStore.preferences!.add_stopped_enabled ?? preferenceStore.preferences!.start_paused_enabled,
   set(v) {
-    if (!preferenceStore.preferences) return;
+    if (!preferenceStore.preferences) return
     preferenceStore.preferences.add_stopped_enabled = v
     preferenceStore.preferences.start_paused_enabled = v
   }
@@ -153,7 +153,8 @@ const closeDeleteDialog = async () => {
 }
 
 async function sendTestEmail() {
-  appStore.sendTestEmail()
+  appStore
+    .sendTestEmail()
     .then(() => toast.success(t('settings.downloads.mailNotification.test.success')))
     .catch(err => toast.error(t('settings.downloads.mailNotification.test.error', { message: err.message })))
 }
@@ -184,10 +185,11 @@ async function sendTestEmail() {
 
       <v-checkbox v-model="preferenceStore.preferences!.incomplete_files_ext" hide-details :label="t('settings.downloads.publicSettings.appendQBExtension')" />
 
-      <v-checkbox v-if="appStore.version >= '5.0.0'"
-                  v-model="preferenceStore.preferences!.use_unwanted_folder"
-                  hide-details
-                  :label="t('settings.downloads.publicSettings.useUnwantedFolder')" />
+      <v-checkbox
+        v-if="appStore.version >= '5.0.0'"
+        v-model="preferenceStore.preferences!.use_unwanted_folder"
+        hide-details
+        :label="t('settings.downloads.publicSettings.useUnwantedFolder')" />
     </v-list-item>
 
     <v-divider />
@@ -226,10 +228,10 @@ async function sendTestEmail() {
         </v-col>
 
         <v-col cols="12" v-if="appStore.version >= '5.0.0'" class="py-0">
-          <v-checkbox v-model="preferenceStore.preferences!.use_category_paths_in_manual_mode"
-                      hide-details
-                      :label="t('settings.downloads.saveManagement.useCategoryPathInManualMode')"
-          />
+          <v-checkbox
+            v-model="preferenceStore.preferences!.use_category_paths_in_manual_mode"
+            hide-details
+            :label="t('settings.downloads.saveManagement.useCategoryPathInManualMode')" />
         </v-col>
 
         <v-col cols="12">

--- a/src/components/Settings/RSS.vue
+++ b/src/components/Settings/RSS.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { usePreferenceStore, useVueTorrentStore } from '@/stores'
+import { useAppStore, usePreferenceStore, useVueTorrentStore } from '@/stores'
 
+const appStore = useAppStore()
 const preferenceStore = usePreferenceStore()
 const vuetorrentStore = useVueTorrentStore()
 </script>
@@ -23,6 +24,15 @@ const vuetorrentStore = useVueTorrentStore()
         </v-col>
         <v-col cols="12" sm="6">
           <v-text-field v-model.number="preferenceStore.preferences!.rss_max_articles_per_feed" type="number" :label="$t('settings.rss.reader.maximumArticlesPerFeed')" />
+        </v-col>
+
+        <v-col cols="12" v-if="appStore.version >= '5.0.0'">
+          <v-text-field
+              v-model.number="preferenceStore.preferences!.rss_fetch_delay"
+              type="number"
+              hide-details
+              :suffix="$t('units.seconds', preferenceStore.preferences!.rss_fetch_delay)"
+              :label="$t('settings.rss.reader.sameHostRequestDelay')" />
         </v-col>
       </v-row>
     </v-list-item>

--- a/src/components/Settings/RSS.vue
+++ b/src/components/Settings/RSS.vue
@@ -29,11 +29,11 @@ const vuetorrentStore = useVueTorrentStore()
 
         <v-col cols="12" md="4" v-if="appStore.version >= '5.0.0'" class="pt-0">
           <v-text-field
-              v-model.number="preferenceStore.preferences!.rss_fetch_delay"
-              type="number"
-              hide-details
-              :suffix="$t('units.seconds', preferenceStore.preferences!.rss_fetch_delay)"
-              :label="$t('settings.rss.reader.sameHostRequestDelay')" />
+            v-model.number="preferenceStore.preferences!.rss_fetch_delay"
+            type="number"
+            hide-details
+            :suffix="$t('units.seconds', preferenceStore.preferences!.rss_fetch_delay!)"
+            :label="$t('settings.rss.reader.sameHostRequestDelay')" />
         </v-col>
       </v-row>
     </v-list-item>

--- a/src/components/Settings/RSS.vue
+++ b/src/components/Settings/RSS.vue
@@ -11,10 +11,11 @@ const vuetorrentStore = useVueTorrentStore()
     <v-list-subheader>{{ $t('settings.rss.reader.subheader') }}</v-list-subheader>
 
     <v-list-item>
-      <v-checkbox v-model="preferenceStore.preferences!.rss_processing_enabled" hide-details :label="$t('settings.rss.reader.enableProcessing')" />
-
       <v-row>
-        <v-col cols="12" sm="6">
+        <v-col cols="12" class="py-0">
+          <v-checkbox v-model="preferenceStore.preferences!.rss_processing_enabled" hide-details :label="$t('settings.rss.reader.enableProcessing')" />
+        </v-col>
+        <v-col cols="12" sm="6" md="4" class="py-0">
           <v-text-field
             v-model.number="preferenceStore.preferences!.rss_refresh_interval"
             type="number"
@@ -22,11 +23,11 @@ const vuetorrentStore = useVueTorrentStore()
             :suffix="$t('units.minutes', preferenceStore.preferences!.rss_refresh_interval)"
             :label="$t('settings.rss.reader.feedsRefreshInterval')" />
         </v-col>
-        <v-col cols="12" sm="6">
+        <v-col cols="12" sm="6" md="4" class="py-0">
           <v-text-field v-model.number="preferenceStore.preferences!.rss_max_articles_per_feed" type="number" :label="$t('settings.rss.reader.maximumArticlesPerFeed')" />
         </v-col>
 
-        <v-col cols="12" v-if="appStore.version >= '5.0.0'">
+        <v-col cols="12" md="4" v-if="appStore.version >= '5.0.0'" class="pt-0">
           <v-text-field
               v-model.number="preferenceStore.preferences!.rss_fetch_delay"
               type="number"
@@ -37,7 +38,7 @@ const vuetorrentStore = useVueTorrentStore()
       </v-row>
     </v-list-item>
 
-    <v-divider />
+    <v-divider class="mt-3" />
     <v-list-subheader>{{ $t('settings.rss.autoDownloader.subheader') }}</v-list-subheader>
 
     <v-list-item>
@@ -70,5 +71,3 @@ const vuetorrentStore = useVueTorrentStore()
     </v-list-item>
   </v-list>
 </template>
-
-<style scoped lang="scss"></style>

--- a/src/constants/qbit/AppPreferences.ts
+++ b/src/constants/qbit/AppPreferences.ts
@@ -33,7 +33,7 @@ export enum ShareLimitAction {
   STOP_TORRENT = 0,
   REMOVE_TORRENT = 1,
   ENABLE_SUPERSEEDING = 2,
-  REMOVE_TORRENT_AND_FILES = 3,
+  REMOVE_TORRENT_AND_FILES = 3
 }
 
 export enum ProxyType {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -660,9 +660,9 @@
         "i2p": {
           "restartNeeded": "Any changes in these settings will take effect the next time the SAM connection is re-established (by restarting I2P or changing I2P address or port)",
           "inboundQuantity": "I2P inbound quantity",
-          "outboundQuantity":"I2P outbound quantity",
+          "outboundQuantity": "I2P outbound quantity",
           "inboundLength": "I2P inbound length",
-          "outboundLength":"I2P outbound length",
+          "outboundLength": "I2P outbound length",
           "invalidQuantity": "I2P quantity values must be between 1 and 16",
           "invalidLength": "I2P length values must be between 0 and 7"
         },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -662,13 +662,16 @@
           "inboundQuantity": "I2P inbound quantity",
           "outboundQuantity":"I2P outbound quantity",
           "inboundLength": "I2P inbound length",
-          "outboundLength":"I2P outbound length"
+          "outboundLength":"I2P outbound length",
+          "invalidQuantity": "I2P quantity values must be between 1 and 16",
+          "invalidLength": "I2P length values must be between 0 and 7"
         },
         "ssl": {
           "disclaimer": "The \"SSL torrent\" feature is not standardized, there are no BEP (BitTorrent Enhancement Proposals) associated with it.\nEnable this feature only when you need it.",
           "enabled": "Enable SSL torrents",
           "listenPort": "Port used for SSL connections",
-          "listenPortHint": "Leave empty to auto-select"
+          "listenPortHint": "Leave empty to auto-select",
+          "rule": "Port must be between 0 and 65535"
         },
         "dhtBootstrapNodes": "DHT bootstrap nodes",
         "dhtBootstrapNodesHint": "Resets to default if empty",
@@ -830,6 +833,7 @@
         "address": "I2P Host",
         "port": "Port",
         "mixedMode": "Mixed Mode",
+        "rule": "Port value must be between 0 and 65535",
         "disclaimer": "If \"Mixed Mode\" is enabled, I2P torrents are allowed to also get peers from other sources than the tracker, and connect to regular IPs, not providing any anonymization. This may be useful if the user is not interested in the anonymization of I2P, but still wants to be able to connect to I2P peers."
       },
       "ipFiltering": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -657,6 +657,21 @@
     },
     "advanced": {
       "libtorrent": {
+        "i2p": {
+          "restartNeeded": "Any changes in these settings will take effect the next time the SAM connection is re-established (by restarting I2P or changing I2P address or port)",
+          "inboundQuantity": "I2P inbound quantity",
+          "outboundQuantity":"I2P outbound quantity",
+          "inboundLength": "I2P inbound length",
+          "outboundLength":"I2P outbound length"
+        },
+        "ssl": {
+          "disclaimer": "The \"SSL torrent\" feature is not standardized, there are no BEP (BitTorrent Enhancement Proposals) associated with it.\nEnable this feature only when you need it.",
+          "enabled": "Enable SSL torrents",
+          "listenPort": "Port used for SSL connections",
+          "listenPortHint": "Leave empty to auto-select"
+        },
+        "dhtBootstrapNodes": "DHT bootstrap nodes",
+        "dhtBootstrapNodesHint": "Resets to default if empty",
         "announceAllTiers": "Always announce to all tiers",
         "announceAllTrackers": "Always announce to all trackers in a tier",
         "announceIP": "IP address reported to trackers (requires restart)",
@@ -718,6 +733,8 @@
       },
       "openDoc": "Open documentation",
       "qbittorrent": {
+        "pythonExecutablePath": "Python executable path",
+        "pythonExecutablePathHint": "Auto detect if empty, require restart",
         "appInstanceName": "App instance name",
         "enableMarkOfTheWeb": "Enable Mark-of-the-Web (MOTW) for downloaded files",
         "enableMarkOfTheWebHint": "require macOS or Windows",
@@ -941,6 +958,7 @@
         "enableProcessing": "Enable fetching RSS feeds",
         "feedsRefreshInterval": "Feeds refresh interval",
         "maximumArticlesPerFeed": "Maximum number of articles per feed",
+        "sameHostRequestDelay": "Same host request delay",
         "subheader": "RSS Reader"
       },
       "smartEpisodeFilter": {
@@ -1375,7 +1393,7 @@
     }
   },
   "units": {
-    "minutes": "minute | minute | minutes",
-    "seconds": "second | second | seconds"
+    "minutes": "minute | minutes",
+    "seconds": "second | seconds"
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -24,6 +24,10 @@
     "yes": "Yes"
   },
   "constants": {
+    "torrentContentRemovingMode": {
+      "delete": "Delete files permanently",
+      "moveToTrash": "Move files to trash (if possible)"
+    },
     "addStopped": {
       "always": "Always",
       "never": "Never",
@@ -714,6 +718,10 @@
       },
       "openDoc": "Open documentation",
       "qbittorrent": {
+        "appInstanceName": "App instance name",
+        "enableMarkOfTheWeb": "Enable Mark-of-the-Web (MOTW) for downloaded files",
+        "enableMarkOfTheWebHint": "require macOS or Windows",
+        "torrentContentRemovingMode": "Torrent content removing mode",
         "allocatedRam": "Physical memory (RAM) usage limit (libtorrent >= 2.0)",
         "embeddedTracker": {
           "enable": "Enable embedded tracker",
@@ -761,7 +769,7 @@
       "performance_warning": "Log performance warning"
     },
     "bittorrent": {
-      "autoAddTrackers": "Automatically add these trackers to new downloads",
+      "autoAddTrackers": "Automatically append these trackers to new downloads",
       "autoAddTrackersHint": "One tracker per line",
       "maxActiveCheckingTorrents": "Max active checking torrents",
       "privacy": {
@@ -798,6 +806,14 @@
         "perTorrentMaxConnection": "Maximum number of connections per torrent",
         "perTorrentMaxUploadSlots": "Maximum number of upload slots per torrent",
         "subheader": "Connection Limits"
+      },
+      "i2p": {
+        "subheader": "I2P (experimental)",
+        "enabled": "Enable I2P",
+        "address": "I2P Host",
+        "port": "Port",
+        "mixedMode": "Mixed Mode",
+        "disclaimer": "If \"Mixed Mode\" is enabled, I2P torrents are allowed to also get peers from other sources than the tracker, and connect to regular IPs, not providing any anonymization. This may be useful if the user is not interested in the anonymization of I2P, but still wants to be able to connect to I2P peers."
       },
       "ipFiltering": {
         "applyToTrackers": "Apply to trackers",
@@ -863,7 +879,8 @@
       },
       "publicSettings": {
         "appendQBExtension": "Append .!qB extension to incomplete files",
-        "preAllocateDisk": "Pre-allocate disk space for all files"
+        "preAllocateDisk": "Pre-allocate disk space for all files",
+        "useUnwantedFolder": "Keep unselected files in \".unwanted\" folder"
       },
       "runExternalProgram": {
         "onAddedEnabled": "Run external program on torrent added",
@@ -894,6 +911,8 @@
           "automatic": "Automatic",
           "manual": "Manual"
         },
+        "useCategoryPathInManualMode": "Use Category paths in Manual Mode",
+        "useCategoryPathInManualModeHint": "Resolve relative Save Path against appropriate Category path instead of Default one",
         "exportDir": "Copy .torrent files to",
         "exportDirFinished": "Copy .torrent files for finished downloads to",
         "keepIncomplete": "Default Download Path (incomplete torrents)",

--- a/src/pages/SearchEngine.vue
+++ b/src/pages/SearchEngine.vue
@@ -33,9 +33,9 @@ const headers = computed(() => [
   { title: t('searchEngine.headers.nbLeechers'), key: 'nbLeechers' },
   ...(appStore.version >= '5.0.0'
     ? [
-      { title: t('searchEngine.headers.engineName'), key: 'engineName' },
-      { title: t('searchEngine.headers.pubDate'), key: 'pubDate' },
-    ]
+        { title: t('searchEngine.headers.engineName'), key: 'engineName' },
+        { title: t('searchEngine.headers.pubDate'), key: 'pubDate' }
+      ]
     : [{ title: t('searchEngine.headers.siteUrl'), key: 'siteUrl' }]),
   { title: '', key: 'actions', sortable: false }
 ])

--- a/src/pages/SearchEngine.vue
+++ b/src/pages/SearchEngine.vue
@@ -19,7 +19,7 @@ const appStore = useAppStore()
 const dialogStore = useDialogStore()
 const searchEngineStore = useSearchEngineStore()
 const { searchData } = storeToRefs(searchEngineStore)
-const vuetorrentStore = useVueTorrentStore()
+const { useBinarySize, dateFormat } = storeToRefs(useVueTorrentStore())
 
 const queryInput = ref<typeof HistoryField>()
 
@@ -180,7 +180,7 @@ onBeforeUnmount(() => {
       <v-container class="d-flex align-center justify-center ma-0 pa-0 bg-primary" fluid>
         <v-tabs v-model="tabIndex" class="overflow-auto" bg-color="primary" show-arrows>
           <v-tab v-for="tab in searchData" :key="tab.uniqueId">
-            <h4>{{ !tab.lastQuery || tab.lastQuery.length === 0 ? $t('searchEngine.tabHeaderEmpty') : tab.lastQuery }}</h4>
+            <h4>{{ !tab.lastQuery || tab.lastQuery.length === 0 ? t('searchEngine.tabHeaderEmpty') : tab.lastQuery }}</h4>
           </v-tab>
         </v-tabs>
 
@@ -203,7 +203,7 @@ onBeforeUnmount(() => {
               density="compact"
               hide-details
               clearable
-              :label="$t('searchEngine.query')"
+              :label="t('searchEngine.query')"
               @keydown.enter.prevent="runNewSearch" />
           </v-col>
 
@@ -215,7 +215,7 @@ onBeforeUnmount(() => {
               density="compact"
               hide-details
               :items="categories"
-              :label="$t('searchEngine.filters.category.label')" />
+              :label="t('searchEngine.filters.category.label')" />
           </v-col>
           <v-col cols="6" sm="5" md="2">
             <v-select
@@ -225,15 +225,15 @@ onBeforeUnmount(() => {
               hide-details
               variant="outlined"
               :items="plugins"
-              :label="$t('searchEngine.filters.plugins.label')" />
+              :label="t('searchEngine.filters.plugins.label')" />
           </v-col>
 
           <v-col cols="12" sm="2" class="d-flex align-center justify-center">
             <v-btn v-if="selectedTab.id === 0" color="accent" flat class="mx-auto px-4" @click="runNewSearch">
-              {{ $t('searchEngine.runSearch') }}
+              {{ t('searchEngine.runSearch') }}
             </v-btn>
             <v-btn v-else color="warning" flat class="mx-auto px-4" @click="stopSearch(selectedTab)">
-              {{ $t('searchEngine.stopSearch') }}
+              {{ t('searchEngine.stopSearch') }}
             </v-btn>
           </v-col>
         </v-row>
@@ -251,15 +251,15 @@ onBeforeUnmount(() => {
           <template v-slot:top>
             <v-row>
               <v-col cols="12">
-                <v-text-field v-model="selectedTab.filters.title" density="compact" hide-details :label="$t('searchEngine.filters.title.label')" />
+                <v-text-field v-model="selectedTab.filters.title" density="compact" hide-details :label="t('searchEngine.filters.title.label')" />
               </v-col>
             </v-row>
           </template>
           <template v-slot:[`item.fileSize`]="{ item }">
-            {{ formatData(item.fileSize, vuetorrentStore.useBinarySize) }}
+            {{ formatData(item.fileSize, useBinarySize) }}
           </template>
           <template v-slot:[`item.pubDate`]="{ value }">
-            {{ formatTimeSec(value, vuetorrentStore.dateFormat) }}
+            {{ value === -1 ? t('common.NA') : formatTimeSec(value, dateFormat) }}
           </template>
           <template v-slot:[`item.actions`]="{ item }">
             <v-btn icon="mdi-open-in-new" variant="flat" density="compact" @click.stop="openLink(item)" />

--- a/src/services/qbit/IProvider.ts
+++ b/src/services/qbit/IProvider.ts
@@ -18,13 +18,7 @@ import {
   Tracker
 } from '@/types/qbit/models'
 import { NetworkInterface } from '@/types/qbit/models/AppPreferences'
-import {
-  AddTorrentPayload,
-  AppPreferencesPayload,
-  CreateFeedPayload,
-  GetTorrentPayload,
-  LoginPayload
-} from '@/types/qbit/payloads'
+import { AddTorrentPayload, AppPreferencesPayload, CreateFeedPayload, GetTorrentPayload, LoginPayload } from '@/types/qbit/payloads'
 import { MaindataResponse, SearchResultsResponse, TorrentPeersResponse } from '@/types/qbit/responses'
 import { AxiosResponse } from 'axios'
 

--- a/src/services/qbit/MockProvider.ts
+++ b/src/services/qbit/MockProvider.ts
@@ -1,19 +1,5 @@
-import {
-  ConnectionStatus,
-  FilePriority,
-  LogType,
-  PieceState,
-  TorrentCreatorTaskStatus,
-  TorrentOperatingMode,
-  TorrentState
-} from '@/constants/qbit'
-import {
-  ContentLayout,
-  ProxyType,
-  ResumeDataStorageType,
-  StopCondition,
-  TorrentContentRemoveOption
-} from '@/constants/qbit/AppPreferences'
+import { ConnectionStatus, FilePriority, LogType, PieceState, TorrentCreatorTaskStatus, TorrentOperatingMode, TorrentState } from '@/constants/qbit'
+import { ContentLayout, ProxyType, ResumeDataStorageType, StopCondition, TorrentContentRemoveOption } from '@/constants/qbit/AppPreferences'
 import type {
   ApplicationVersion,
   AppPreferences,
@@ -64,8 +50,7 @@ export default class MockProvider implements IProvider {
     .fill('')
     .map((_, i) => (i + 1).toString(16).padStart(40, '0'))
 
-  private constructor() {
-  }
+  private constructor() {}
 
   static getInstance(): MockProvider {
     if (!MockProvider.instance) {
@@ -107,7 +92,7 @@ export default class MockProvider implements IProvider {
       infohash_v1: hash,
       infohash_v2: '',
       last_activity: last_activity.getTime() / 1000,
-      magnet_uri: `magnet:?xt=urn:btih:${ hash }&dn=${ name }&tr=${ tracker }`,
+      magnet_uri: `magnet:?xt=urn:btih:${hash}&dn=${name}&tr=${tracker}`,
       max_inactive_seeding_time: -1,
       max_ratio: -1,
       max_seeding_time: -1,
@@ -432,7 +417,7 @@ export default class MockProvider implements IProvider {
 
   async getDirectoryContent(dirPath: string, _?: 'dirs' | 'files' | 'all'): Promise<string[]> {
     return this.generateResponse({
-      result: faker.helpers.multiple(() => `${ dirPath }/${ faker.system.fileName() }`, { count: { min: 0, max: 5 } })
+      result: faker.helpers.multiple(() => `${dirPath}/${faker.system.fileName()}`, { count: { min: 0, max: 5 } })
     })
   }
 
@@ -1154,7 +1139,7 @@ export default class MockProvider implements IProvider {
         full_update: true,
         rid: rid + 1,
         peers: {
-          [`${ ip1 }:${ port1 }`]: {
+          [`${ip1}:${port1}`]: {
             client: 'qBittorrent v4.6.2',
             connection: rndmConnType(),
             country: rndmCountry(),
@@ -1172,7 +1157,7 @@ export default class MockProvider implements IProvider {
             up_speed: rndmSpeed(),
             uploaded: rndmData()
           },
-          [`${ ip2 }:${ port2 }`]: {
+          [`${ip2}:${port2}`]: {
             client: 'Tixati 2.84',
             connection: rndmConnType(),
             country: rndmCountry(),
@@ -1190,7 +1175,7 @@ export default class MockProvider implements IProvider {
             up_speed: faker.number.int(50_000_000), // [0; 50 Mo/s]
             uploaded: rndmData()
           },
-          [`${ ip3 }:${ port3 }`]: {
+          [`${ip3}:${port3}`]: {
             client: 'Deluge/2.1.1 libtorrent/2.0.5.0',
             connection: rndmConnType(),
             country: rndmCountry(),
@@ -1235,18 +1220,22 @@ export default class MockProvider implements IProvider {
           comment: faker.word.words({ count: { min: 0, max: 25 } }),
           torrentFilePath: faker.system.filePath(),
           source: faker.system.directoryPath(),
-          trackers: faker.helpers.multiple(() => faker.internet.url(), {
-            count: faker.number.int({
-              min: 0,
-              max: 5
+          trackers: faker.helpers
+            .multiple(() => faker.internet.url(), {
+              count: faker.number.int({
+                min: 0,
+                max: 5
+              })
             })
-          }).join('|'),
-          urlSeeds: faker.helpers.multiple(() => faker.internet.url(), {
-            count: faker.number.int({
-              min: 0,
-              max: 5
+            .join('|'),
+          urlSeeds: faker.helpers
+            .multiple(() => faker.internet.url(), {
+              count: faker.number.int({
+                min: 0,
+                max: 5
+              })
             })
-          }).join('|'),
+            .join('|'),
           timeFinished: faker.date.recent().toString(),
           timeStarted: faker.date.past().toString()
         }

--- a/src/services/qbit/QbitProvider.ts
+++ b/src/services/qbit/QbitProvider.ts
@@ -19,13 +19,7 @@ import type {
   Tracker
 } from '@/types/qbit/models'
 import { NetworkInterface } from '@/types/qbit/models/AppPreferences'
-import type {
-  AddTorrentPayload,
-  AppPreferencesPayload,
-  CreateFeedPayload,
-  GetTorrentPayload,
-  LoginPayload
-} from '@/types/qbit/payloads'
+import type { AddTorrentPayload, AppPreferencesPayload, CreateFeedPayload, GetTorrentPayload, LoginPayload } from '@/types/qbit/payloads'
 import type { MaindataResponse, SearchResultsResponse, TorrentPeersResponse } from '@/types/qbit/responses'
 import type { AxiosInstance } from 'axios'
 import axios, { AxiosResponse } from 'axios'
@@ -353,8 +347,7 @@ export default class QBitProvider implements IProvider {
   }
 
   async status(taskID?: string): Promise<TorrentCreatorTask[]> {
-    return this.axios.get('/torrentcreator/status', { params: { taskID } })
-      .then(res => res.data)
+    return this.axios.get('/torrentcreator/status', { params: { taskID } }).then(res => res.data)
   }
 
   async torrentFile(taskID: string): Promise<Blob> {
@@ -681,8 +674,7 @@ export default class QBitProvider implements IProvider {
   }
 
   async SSLParameters(hash: string): Promise<SSLParameters> {
-    return this.axios.get('/torrents/SSLParameters', { params: { hash } })
-      .then(res => res.data)
+    return this.axios.get('/torrents/SSLParameters', { params: { hash } }).then(res => res.data)
   }
 
   async setSSLParameters(hash: string, params: SSLParameters): Promise<boolean> {
@@ -690,7 +682,7 @@ export default class QBitProvider implements IProvider {
       hash,
       ssl_certificate: params.ssl_certificate,
       ssl_private_key: params.ssl_private_key,
-      ssl_dh_params: params.ssl_dh_params,
+      ssl_dh_params: params.ssl_dh_params
     })
       .then(() => true)
       .catch(() => false)

--- a/src/types/qbit/models/AppPreferences.ts
+++ b/src/types/qbit/models/AppPreferences.ts
@@ -430,36 +430,36 @@ export default interface AppPreferences {
   torrent_content_remove_option?: TorrentContentRemoveOption
   /** Whether to move unwanted files to a separate folder */
   use_unwanted_folder?: boolean
-  /** TODO: Self-explanatory, in seconds */
+  /** Same host request delay, in seconds */
   rss_fetch_delay?: number
   /** Delete torrent contents files on torrent removal, for WebUI */
   delete_torrent_content_files?: boolean
-  /** TODO: True if torrents should be added in a Stopped state */
+  /** True if torrents should be added in a Stopped state */
   add_stopped_enabled?: boolean
   /** qBittorrent instance name */
   app_instance_name?: string
   /** Should the MotW be enabled and handled by qBittorrent */
   mark_of_the_web?: boolean
-  /** TODO: Custom Python executable path, for search engines */
+  /** Custom Python executable path, for search engines */
   python_executable_path?: string
-  /** TODO: Backup nodes to use if unknown */
+  /** Backup nodes to use if unknown */
   dht_bootstrap_nodes?: string
 
-  /** TODO */
+  /** Whether to enable I2P torrents mode */
   i2p_enabled?: boolean
-  /** TODO */
+  /** Address to bind to for I2P torrents */
   i2p_address?: string
-  /** TODO */
+  /** Port to bind to for I2P torrents */
   i2p_port?: number
-  /** TODO */
+  /** Whether to use mixed mode for I2P torrents */
   i2p_mixed_mode?: boolean
-  /** TODO */
+  /** SAM session quantity of I2P inbound tunnels */
   i2p_inbound_quantity?: number
-  /** TODO */
+  /** SAM session quantity of I2P outbound tunnels */
   i2p_outbound_quantity?: number
-  /** TODO */
+  /** SAM session number of hops for I2P inbound tunnels */
   i2p_inbound_length?: number
-  /** TODO */
+  /** SAM session number of hops for I2P outbound tunnels */
   i2p_outbound_length?: number
 }
 

--- a/src/types/qbit/models/AppPreferences.ts
+++ b/src/types/qbit/models/AppPreferences.ts
@@ -423,27 +423,44 @@ export default interface AppPreferences {
   web_ui_username: string
 
   /** TODO: Should qBittorrent listen on ssl ports */
-  ssl_enabled: boolean
+  ssl_enabled?: boolean
   /** TODO: SSL port to use when `ssl_enabled` is enabled */
-  ssl_listen_port: number
-  /** TODO: Which action will be taken when removing torrent content */
-  torrent_content_remove_option: TorrentContentRemoveOption
-  /** TODO: Whether to move unwanted files to a separate folder */
-  use_unwanted_folder: boolean
+  ssl_listen_port?: number
+  /** Which action will be taken when removing torrent content */
+  torrent_content_remove_option?: TorrentContentRemoveOption
+  /** Whether to move unwanted files to a separate folder */
+  use_unwanted_folder?: boolean
   /** TODO: Self-explanatory, in seconds */
-  rss_fetch_delay: number
-  /** TODO: Delete torrent contents files on torrent removal, for WebUI */
-  delete_torrent_content_files: boolean
+  rss_fetch_delay?: number
+  /** Delete torrent contents files on torrent removal, for WebUI */
+  delete_torrent_content_files?: boolean
   /** TODO: True if torrents should be added in a Stopped state */
-  add_stopped_enabled: boolean
-  /** TODO: qBittorrent instance name */
-  app_instance_name: string
-  /** TODO: Should the MotW be enabled and handled by qBittorrent */
-  mark_of_the_web: boolean
+  add_stopped_enabled?: boolean
+  /** qBittorrent instance name */
+  app_instance_name?: string
+  /** Should the MotW be enabled and handled by qBittorrent */
+  mark_of_the_web?: boolean
   /** TODO: Custom Python executable path, for search engines */
-  python_executable_path: string
+  python_executable_path?: string
   /** TODO: Backup nodes to use if unknown */
-  dht_bootstrap_nodes: string
+  dht_bootstrap_nodes?: string
+
+  /** TODO */
+  i2p_enabled?: boolean
+  /** TODO */
+  i2p_address?: string
+  /** TODO */
+  i2p_port?: number
+  /** TODO */
+  i2p_mixed_mode?: boolean
+  /** TODO */
+  i2p_inbound_quantity?: number
+  /** TODO */
+  i2p_outbound_quantity?: number
+  /** TODO */
+  i2p_inbound_length?: number
+  /** TODO */
+  i2p_outbound_length?: number
 }
 
 /** Preferences extension from Enhanced qBittorrent edition */


### PR DESCRIPTION
- SearchEngine:
  - Replaced siteUrl with engineName and pubDate
  - download torrent using plugin instead of adding to queue
- Settings:
  - Advanced:
    - torrent content remove option
    - app instance name
    - mark of the web
    - python executable path
    - I2P inbound/outbound quantity/length
    - SSL torrents
  - Connection:
    - I2P support (address / port / mixed mode)
  - Downloads:
    - Unwanted folder
    - category path in manual mode
    - test email
  - RSS:
    - same domain fetch delay
