### PR TITLE
perf(DeleteTorrentDialog): Remap incorrect binding and persist on-demand

### DIFF
--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -1,3 +1,4 @@
+import { AppPreferencesPayload } from '@/types/qbit/payloads'
 import { ref } from 'vue'
 import { acceptHMRUpdate, defineStore } from 'pinia'
 import AppPreferences from '@/types/qbit/models/AppPreferences'
@@ -12,8 +13,8 @@ export const usePreferenceStore = defineStore(
       preferences.value = await qbit.getPreferences()
     }
 
-    async function setPreferences() {
-      await qbit.setPreferences(preferences.value!)
+    async function setPreferences(newPref?: AppPreferencesPayload) {
+      await qbit.setPreferences(newPref ?? preferences.value!)
     }
 
     return {

--- a/src/stores/vuetorrent.ts
+++ b/src/stores/vuetorrent.ts
@@ -36,6 +36,7 @@ export const useVueTorrentStore = defineStore(
     const showAlltimeStat = ref(true)
     const showCurrentSpeed = ref(true)
     const showSpeedInTitle = ref(false)
+    /** @deprecated */
     const deleteWithFiles = ref(false)
     const uiTitleType = ref(TitleOptions.DEFAULT)
     const uiTitleCustom = ref('')


### PR DESCRIPTION
Invalid map with the qBit 5 update, fixes #1951

Also used this for persisting the state on demand with the new flag, fixes #1907

On load (uses previous state so save action is disabled):
![image](https://github.com/user-attachments/assets/e96bfc0f-42d4-4fe2-bfb0-26b105c5161c)

After change, button is unlocked:
![image](https://github.com/user-attachments/assets/bcf85ed8-7002-47e5-a3b0-5ae144d21c8f)

On click, state has changed => disabled again:
![image](https://github.com/user-attachments/assets/8d9361ca-bd0b-428b-bf21-0d31f8827394)
