### PR TITLE
  [fix] The peer info misplaced when no country flag returned.

### DIFF
--- a/src/components/TorrentDetail/Peers.vue
+++ b/src/components/TorrentDetail/Peers.vue
@@ -162,13 +162,9 @@ onBeforeRouteUpdate(() => !addPeersDialog.value)
 
       <template #[`item.country`]="{ item }">
         <div v-if="showCountryFlags" class="cursor-help" :title="item.country">
-          <template v-if="item.country_code">
-            <img v-if="isWindows" :alt="codeToFlag(item.country_code!).char" :src="codeToFlag(item.country_code!).url" :title="item.country" style="max-width: 32px" />
-            <span v-else :title="item.country">{{ codeToFlag(item.country_code!).char }}</span>
-          </template>
-          <template v-else>
-            <span></span>
-          </template>
+          <span v-if="!item.country_code"></span>
+          <img v-else-if="isWindows" :alt="codeToFlag(item.country_code).char" :src="codeToFlag(item.country_code).url" :title="item.country" style="max-width: 32px" />
+          <span v-else :title="item.country">{{ codeToFlag(item.country_code).char }}</span>
         </div>
       </template>
 

--- a/src/components/TorrentDetail/Peers.vue
+++ b/src/components/TorrentDetail/Peers.vue
@@ -162,8 +162,13 @@ onBeforeRouteUpdate(() => !addPeersDialog.value)
 
       <template #[`item.country`]="{ item }">
         <div v-if="showCountryFlags" class="cursor-help" :title="item.country">
-          <img v-if="isWindows" :alt="codeToFlag(item.country_code!).char" :src="codeToFlag(item.country_code!).url" :title="item.country" style="max-width: 32px" />
-          <span v-else :title="item.country">{{ codeToFlag(item.country_code!).char }}</span>
+          <template v-if="item.country_code">
+            <img v-if="isWindows" :alt="codeToFlag(item.country_code!).char" :src="codeToFlag(item.country_code!).url" :title="item.country" style="max-width: 32px" />
+            <span v-else :title="item.country">{{ codeToFlag(item.country_code!).char }}</span>
+          </template>
+          <template v-else>
+            <span></span>
+          </template>
         </div>
       </template>
 


### PR DESCRIPTION
Fixes #1872

Occasionally the peer host gets the gateway IP which is a local IP address(as 192.168.0.1). Check whether to add blank before getting the flag.

![Screenshot 2024-10-08 134725](https://github.com/user-attachments/assets/2dbcf374-fdff-445e-87d6-074df5f66509)

