### PR TITLE
fix(Dashboard): Make checkbox click events even with torrent card

### DIFF
--- a/src/components/Dashboard/Views/Grid/GridView.vue
+++ b/src/components/Dashboard/Views/Grid/GridView.vue
@@ -10,7 +10,7 @@ defineProps<{
 }>()
 
 defineEmits<{
-  onCheckboxClick: [torrent: TorrentType]
+  onCheckboxClick: [e: { shiftKey: boolean; metaKey: boolean; ctrlKey: boolean }, torrent: TorrentType]
   onTorrentClick: [e: { shiftKey: boolean; metaKey: boolean; ctrlKey: boolean }, torrent: TorrentType]
   onTorrentDblClick: [torrent: TorrentType]
   onTorrentRightClick: [e: MouseEvent, torrent: TorrentType]
@@ -47,7 +47,7 @@ const dashboardStore = useDashboardStore()
             :icon="dashboardStore.isTorrentInSelection(torrent.hash) ? 'mdi-checkbox-marked' : 'mdi-checkbox-blank-outline'"
             class="mr-2"
             variant="text"
-            @click="$emit('onCheckboxClick', torrent)" />
+            @click="$emit('onCheckboxClick', $event, torrent)" />
         </v-expand-x-transition>
         <GridTorrent :torrent="torrent" @onTorrentClick="(e, t) => $emit('onTorrentClick', e, t)" />
       </div>

--- a/src/components/Dashboard/Views/List/ListView.vue
+++ b/src/components/Dashboard/Views/List/ListView.vue
@@ -10,7 +10,7 @@ defineProps<{
 }>()
 
 defineEmits<{
-  onCheckboxClick: [torrent: TorrentType]
+  onCheckboxClick: [e: { shiftKey: boolean; metaKey: boolean; ctrlKey: boolean }, torrent: TorrentType]
   onTorrentClick: [e: { shiftKey: boolean; metaKey: boolean; ctrlKey: boolean }, torrent: TorrentType]
   onTorrentDblClick: [torrent: TorrentType]
   onTorrentRightClick: [e: MouseEvent, torrent: TorrentType]
@@ -43,7 +43,7 @@ const dashboardStore = useDashboardStore()
             :icon="dashboardStore.isTorrentInSelection(torrent.hash) ? 'mdi-checkbox-marked' : 'mdi-checkbox-blank-outline'"
             class="mr-2"
             variant="text"
-            @click="$emit('onCheckboxClick', torrent)" />
+            @click="$emit('onCheckboxClick', $event, torrent)" />
         </v-expand-x-transition>
         <ListTorrent :torrent="torrent" @onTorrentClick="(e, t) => $emit('onTorrentClick', e, t)" />
       </div>

--- a/src/components/Dashboard/Views/Table/TableView.vue
+++ b/src/components/Dashboard/Views/Table/TableView.vue
@@ -14,7 +14,7 @@ defineProps<{
 }>()
 
 defineEmits<{
-  onCheckboxClick: [torrent: TorrentType]
+  onCheckboxClick: [e: { shiftKey: boolean; metaKey: boolean; ctrlKey: boolean }, torrent: TorrentType]
   onTorrentClick: [e: { shiftKey: boolean; metaKey: boolean; ctrlKey: boolean }, torrent: TorrentType]
   onTorrentDblClick: [torrent: TorrentType]
   onTorrentRightClick: [e: MouseEvent, torrent: TorrentType]
@@ -79,7 +79,7 @@ const getTorrentRowColorClass = (torrent: TorrentType) => [isTorrentSelected(tor
             :model-value="isTorrentSelected(torrent)"
             :color="`torrent-${TorrentState[torrent.state].toLowerCase()}`"
             variant="text"
-            @click.stop="$emit('onCheckboxClick', torrent)" />
+            @click.stop="$emit('onCheckboxClick', $event, torrent)" />
         </td>
         <td>{{ torrent.name }}</td>
         <TableTorrent :torrent="torrent" />

--- a/src/pages/Dashboard.vue
+++ b/src/pages/Dashboard.vue
@@ -67,10 +67,6 @@ function goToInfo(torrent: TorrentType) {
   }
 }
 
-function onCheckboxClick(torrent: TorrentType) {
-  dashboardStore.toggleSelect(torrent.hash)
-}
-
 function onTorrentClick(e: { shiftKey: boolean; metaKey: boolean; ctrlKey: boolean }, torrent: TorrentType) {
   if (e.shiftKey) {
     dashboardStore.spanTorrentSelection(torrent.hash)
@@ -226,9 +222,9 @@ onBeforeUnmount(() => {
     <ListView
       v-else-if="isListView"
       :paginated-torrents="paginatedTorrents"
+      @onCheckboxClick="onTorrentClick"
       @onTorrentClick="onTorrentClick"
       @onTorrentDblClick="goToInfo"
-      @onCheckboxClick="onCheckboxClick"
       @onTorrentRightClick="onTorrentRightClick"
       @startPress="startPress"
       @endPress="endPress" />
@@ -236,18 +232,18 @@ onBeforeUnmount(() => {
       v-else-if="isGridView"
       class="mb-2"
       :paginated-torrents="paginatedTorrents"
+      @onCheckboxClick="onTorrentClick"
       @onTorrentClick="onTorrentClick"
       @onTorrentDblClick="goToInfo"
-      @onCheckboxClick="onCheckboxClick"
       @onTorrentRightClick="onTorrentRightClick"
       @startPress="startPress"
       @endPress="endPress" />
     <TableView
       v-else-if="isTableView"
       :paginated-torrents="paginatedTorrents"
+      @onCheckboxClick="onTorrentClick"
       @onTorrentClick="onTorrentClick"
       @onTorrentDblClick="goToInfo"
-      @onCheckboxClick="onCheckboxClick"
       @onTorrentRightClick="onTorrentRightClick"
       @startPress="startPress"
       @endPress="endPress" />


### PR DESCRIPTION
Reported on Discord, uses the same event handler for both the checkbox and the torrent card