### PR TITLE
fix(TableView): Set max width of torrent name to 40%

### DIFF
--- a/src/components/Dashboard/Views/Table/TableTorrent.vue
+++ b/src/components/Dashboard/Views/Table/TableTorrent.vue
@@ -46,7 +46,7 @@ const getComponent = (type: DashboardPropertyType) => {
 
 <template>
   <template v-for="ppt in torrentProperties">
-    <component v-if="ppt.props" :is="getComponent(ppt.type)" :torrent="torrent" v-bind="ppt.props" />
+    <component v-if="ppt.props" :is="getComponent(ppt.type)" :torrent="torrent" v-bind="ppt.props" :class="`torrent-${ppt.name}`" />
   </template>
 </template>
 

--- a/src/components/Dashboard/Views/Table/TableView.vue
+++ b/src/components/Dashboard/Views/Table/TableView.vue
@@ -81,14 +81,14 @@ const getTorrentRowColorClass = (torrent: TorrentType) => [isTorrentSelected(tor
             variant="text"
             @click.stop="$emit('onCheckboxClick', $event, torrent)" />
         </td>
-        <td>{{ torrent.name }}</td>
+        <td class="torrent-name text-no-wrap">{{ torrent.name }}</td>
         <TableTorrent :torrent="torrent" />
       </tr>
     </tbody>
   </v-table>
 </template>
 
-<style scoped lang="scss">
+<style lang="scss">
 @use 'vuetify/settings';
 
 #torrentList {
@@ -110,6 +110,12 @@ const getTorrentRowColorClass = (torrent: TorrentType) => [isTorrentSelected(tor
       height: 100%;
       pointer-events: none;
     }
+  }
+
+  .torrent-name {
+    max-width: 40vw;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }
 </style>


### PR DESCRIPTION
#1401

Tried to have a width editable by the user, I haven't found a way yet.

Quick fix to restrict max width to 40% of the user screen.