### PR TITLE
feat(Logs): Add sort support

### DIFF
--- a/src/pages/Logs.vue
+++ b/src/pages/Logs.vue
@@ -16,7 +16,7 @@ const { t } = useI18nUtils()
 const { current } = useTheme()
 
 const logStore = useLogStore()
-const { filteredLogs, logTypeFilter, logMessageFilter, paginatedResults, currentPage, pageCount } = storeToRefs(logStore)
+const { filteredLogs, logTypeFilter, logMessageFilter, paginatedResults, currentPage, pageCount, reverseSort } = storeToRefs(logStore)
 const vueTorrentStore = useVueTorrentStore()
 
 const colors = computed(() => ({
@@ -90,6 +90,7 @@ onUnmounted(() => {
       </v-col>
       <v-col>
         <div class="d-flex justify-end">
+          <v-btn :icon="reverseSort ? 'mdi-sort-descending' : 'mdi-sort-ascending'" variant="plain" @click="reverseSort = !reverseSort" />
           <v-btn icon="mdi-close" variant="plain" @click="goHome" />
         </div>
       </v-col>

--- a/src/stores/logs.ts
+++ b/src/stores/logs.ts
@@ -26,7 +26,7 @@ export const useLogStore = defineStore(
     const filteredLogsByType = computed(() => logs.value.filter(log => logTypeFilter.value.includes(log.type)))
     const { results: filteredLogs } = useSearchQuery(filteredLogsByType, logMessageFilter, log => log.message)
     const { paginatedResults, currentPage, pageCount } = useArrayPagination(
-      () => filteredLogs.value.toSorted((a, b) => comparators.numeric.compare(a.id, b.id, reverseSort.value)),
+      () => filteredLogs.value.toSorted((a, b) => comparators.numeric.compare(a.id, b.id, !reverseSort.value)),
       30
     )
     const logTask = useTask(function* (_: AbortSignal, lastId?: number) {

--- a/src/stores/logs.ts
+++ b/src/stores/logs.ts
@@ -1,5 +1,6 @@
 import { useArrayPagination, useSearchQuery } from '@/composables'
 import { LogType } from '@/constants/qbit'
+import { comparators } from '@/helpers'
 import qbit from '@/services/qbit'
 import { Log } from '@/types/qbit/models'
 import { whenever } from '@vueuse/core'
@@ -25,11 +26,9 @@ export const useLogStore = defineStore(
     const filteredLogsByType = computed(() => logs.value.filter(log => logTypeFilter.value.includes(log.type)))
     const { results: filteredLogs } = useSearchQuery(filteredLogsByType, logMessageFilter, log => log.message)
     const { paginatedResults, currentPage, pageCount } = useArrayPagination(
-      computed(() => {
-        return [...filteredLogs.value.sort((a,b) => reverseSort.value ? (b.id - a.id) : (a.id - b.id))];
-      }),
+      () => filteredLogs.value.toSorted((a, b) => comparators.numeric.compare(a.id, b.id, reverseSort.value)),
       30
-    );
+    )
     const logTask = useTask(function* (_: AbortSignal, lastId?: number) {
       yield fetchLogs(lastId)
     }).drop()


### PR DESCRIPTION
# sorting functionality in logs view [feat]

Closes #2035

As requested, I have implemented a sort button in logs view

<img width="1513" alt="Screenshot 2024-11-14 at 4 27 40 AM" src="https://github.com/user-attachments/assets/6b15081f-0ca8-4fb2-b86e-af23a579d842">
<img width="1484" alt="Screenshot 2024-11-14 at 4 29 30 AM" src="https://github.com/user-attachments/assets/d434918b-94ae-4ffa-b0af-0c54c8ddef18">
<img width="1513" alt="Screenshot 2024-11-14 at 4 27 40 AM" src="https://github.com/user-attachments/assets/8b5d25a4-2efa-4d00-8691-12dd20364085">

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
