### PR TITLE
fix(filters): Don't count offline torrent in "Not working" tracker filter

### DIFF
--- a/src/stores/categories.ts
+++ b/src/stores/categories.ts
@@ -1,10 +1,10 @@
 import { comparators } from '@/helpers'
 import qbit from '@/services/qbit'
-import { useTorrentStore } from '@/stores/torrents.ts'
 import { Category } from '@/types/qbit/models'
 import { useSorted } from '@vueuse/core'
 import { acceptHMRUpdate, defineStore, storeToRefs } from 'pinia'
 import { computed, shallowRef, triggerRef } from 'vue'
+import { useTorrentStore } from './torrents'
 
 export const useCategoryStore = defineStore('categories', () => {
   /** Key: Category name */

--- a/src/stores/content.ts
+++ b/src/stores/content.ts
@@ -1,8 +1,6 @@
 import { useI18nUtils, useSearchQuery, useTreeBuilder } from '@/composables'
 import { FilePriority } from '@/constants/qbit'
 import qbit from '@/services/qbit'
-import { useDialogStore } from '@/stores/dialog'
-import { useVueTorrentStore } from '@/stores/vuetorrent'
 import { TorrentFile } from '@/types/qbit/models'
 import { RightClickMenuEntryType, RightClickProperties, TreeFolder, TreeNode } from '@/types/vuetorrent'
 import { useIntervalFn } from '@vueuse/core'
@@ -10,6 +8,8 @@ import { acceptHMRUpdate, defineStore, storeToRefs } from 'pinia'
 import { computed, nextTick, reactive, shallowRef, toRaw, triggerRef } from 'vue'
 import { useTask } from 'vue-concurrency'
 import { useRoute } from 'vue-router'
+import { useDialogStore } from './dialog'
+import { useVueTorrentStore } from './vuetorrent'
 
 export const useContentStore = defineStore('content', () => {
   const { t } = useI18nUtils()

--- a/src/stores/tags.ts
+++ b/src/stores/tags.ts
@@ -1,9 +1,9 @@
 import { comparators } from '@/helpers'
 import qbit from '@/services/qbit'
-import { useTorrentStore } from '@/stores/torrents.ts'
 import { useSorted } from '@vueuse/core'
 import { acceptHMRUpdate, defineStore, storeToRefs } from 'pinia'
 import { computed, shallowRef, triggerRef } from 'vue'
+import { useTorrentStore } from './torrents'
 
 export const useTagStore = defineStore('tags', () => {
   const _tags = shallowRef<Set<string>>(new Set())

--- a/src/stores/torrents.ts
+++ b/src/stores/torrents.ts
@@ -11,6 +11,19 @@ import { useAppStore } from './app'
 import { useTorrentDetailStore } from './torrentDetail'
 import { useTrackerStore } from './trackers'
 
+const torrentStateNotAnnounced = [
+  TorrentState.UNKNOWN,
+  TorrentState.ERROR,
+  TorrentState.MISSING_FILES,
+  TorrentState.DL_STOPPED,
+  TorrentState.UL_STOPPED,
+  TorrentState.UL_QUEUED,
+  TorrentState.DL_QUEUED,
+  TorrentState.CHECKING_DISK,
+  TorrentState.CHECKING_RESUME_DATA,
+  TorrentState.MOVING
+]
+
 export const useTorrentStore = defineStore(
   'torrents',
   () => {
@@ -81,7 +94,7 @@ export const useTorrentStore = defineStore(
           if (trackers.length === 0) {
             acc[TrackerSpecialFilter.UNTRACKED] = (acc[TrackerSpecialFilter.UNTRACKED] ?? 0) + 1
             return acc
-          } else if (torrent.tracker === '') {
+          } else if (torrent.tracker === '' && !torrentStateNotAnnounced.includes(torrent.state)) {
             acc[TrackerSpecialFilter.NOT_WORKING] = (acc[TrackerSpecialFilter.NOT_WORKING] ?? 0) + 1
             return acc
           }

--- a/src/stores/torrents.ts
+++ b/src/stores/torrents.ts
@@ -11,22 +11,22 @@ import { useAppStore } from './app'
 import { useTorrentDetailStore } from './torrentDetail'
 import { useTrackerStore } from './trackers'
 
-const torrentStateNotAnnounced = [
-  TorrentState.UNKNOWN,
-  TorrentState.ERROR,
-  TorrentState.MISSING_FILES,
-  TorrentState.DL_STOPPED,
-  TorrentState.UL_STOPPED,
-  TorrentState.UL_QUEUED,
-  TorrentState.DL_QUEUED,
-  TorrentState.CHECKING_DISK,
-  TorrentState.CHECKING_RESUME_DATA,
-  TorrentState.MOVING
-]
-
 export const useTorrentStore = defineStore(
   'torrents',
   () => {
+    const torrentStateNotAnnounced = [
+      TorrentState.UNKNOWN,
+      TorrentState.ERROR,
+      TorrentState.MISSING_FILES,
+      TorrentState.DL_STOPPED,
+      TorrentState.UL_STOPPED,
+      TorrentState.UL_QUEUED,
+      TorrentState.DL_QUEUED,
+      TorrentState.CHECKING_DISK,
+      TorrentState.CHECKING_RESUME_DATA,
+      TorrentState.MOVING
+    ]
+
     const appStore = useAppStore()
     const { buildFromQbit } = useTorrentBuilder()
     const trackerStore = useTrackerStore()
@@ -143,7 +143,7 @@ export const useTorrentStore = defineStore(
           case TrackerSpecialFilter.UNTRACKED:
             return torrentTrackers.length === 0
           case TrackerSpecialFilter.NOT_WORKING:
-            return torrentTrackers.length > 0 && t.tracker === ''
+            return torrentTrackers.length > 0 && t.tracker === '' && !torrentStateNotAnnounced.includes(t.state)
           default:
             return torrentTrackers.includes(tracker)
         }


### PR DESCRIPTION
Fixes #2048
#2049

Add exceptions in "Not working" filter.

List of excluded filters are all torrent states that don't communicate with external peers.

