### PR TITLE
Fixed disabling of i2p settings when i2p is enabled

### DIFF
--- a/src/components/Settings/Connection.vue
+++ b/src/components/Settings/Connection.vue
@@ -163,14 +163,14 @@ watch(
           <v-col cols="12" md="6" class="py-0">
             <v-text-field
               v-model="preferenceStore.preferences!.i2p_address"
-              :disabled="preferenceStore.preferences!.i2p_enabled"
+              :disabled="!preferenceStore.preferences!.i2p_enabled"
               hide-details
               :label="t('settings.connection.i2p.address')" />
           </v-col>
           <v-col cols="12" md="6" class="py-0">
             <v-text-field
               v-model="preferenceStore.preferences!.i2p_port"
-              :disabled="preferenceStore.preferences!.i2p_enabled"
+              :disabled="!preferenceStore.preferences!.i2p_enabled"
               :rules="portRule"
               type="number"
               min="0"
@@ -181,7 +181,7 @@ watch(
           <v-col cols="12" class="py-0">
             <v-checkbox
               v-model="preferenceStore.preferences!.i2p_mixed_mode"
-              :disabled="preferenceStore.preferences!.i2p_enabled"
+              :disabled="!preferenceStore.preferences!.i2p_enabled"
               hide-details
               :label="t('settings.connection.i2p.mixedMode')" />
           </v-col>


### PR DESCRIPTION
# Fixed disabling of i2p settings when i2p is enabled

Previously, the I2P settings were disabled when I2P itself was disabled and vice versa, leading to the following:
![image](https://github.com/user-attachments/assets/af19388a-754e-47ec-ba8d-f6f213a53b17)
![image](https://github.com/user-attachments/assets/53bb1497-c8b8-4475-81ec-580606a361ae)

This PR fixes this, so that you can edit the settings when I2P is enabled, and cannot when it is disabled.

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
