### PR TITLE
perf: Handle paste event globally

### DIFF
--- a/src/components/DnDZone.vue
+++ b/src/components/DnDZone.vue
@@ -45,6 +45,26 @@ function extractDropData(files: File[] | null, dataTransfer: DataTransfer): [Fil
   return [torrentFiles, links]
 }
 
+function extractPasteData(event: ClipboardEvent): [File[], string[]] {
+  const clipboardData = event.clipboardData;
+  if (!clipboardData) {
+    return [[], []];
+  }
+
+  const files: File[] = Array.from(clipboardData.items)
+    .filter(item => item.kind === 'file')
+    .map(item => item.getAsFile())
+    .filter((file): file is File => !!file)
+    .filter(file => file.type === 'application/x-bittorrent' || file.name.endsWith('.torrent'));
+
+  const links = clipboardData
+    .getData('text/plain')
+    .split('\n')
+    .filter(link => link.startsWith('magnet:') || link.startsWith('http'));
+
+  return [files, links];
+}
+
 function onQueueDrop(files: File[] | null, event: DragEvent) {
   if (!checkDropEvent(event)) return
 
@@ -77,10 +97,29 @@ function onDownloadDrop(files: File[] | null, event: DragEvent) {
   )
 }
 
+function onPaste(event: ClipboardEvent) {
+  if (document.activeElement?.tagName === 'INPUT') {
+    return false
+  }
+
+  event.preventDefault()
+
+  const [torrentFiles, links] = extractPasteData(event)
+
+  torrentFiles.forEach(addTorrentStore.pushTorrentToQueue)
+  links.forEach(addTorrentStore.pushTorrentToQueue)
+
+  if ((torrentFiles.length || links.length) && !dialogStore.hasActiveDialog) {
+    dialogStore.createDialog(AddTorrentDialog)
+  }
+}
+
 onMounted(() => {
+  document.addEventListener('paste', onPaste)
   document.addEventListener('dragenter', onDragEnter)
 })
 onUnmounted(() => {
+  document.removeEventListener('paste', onPaste)
   document.removeEventListener('dragenter', onDragEnter)
 })
 </script>


### PR DESCRIPTION
Handles torrent files and magnet / http(s) links.

Don't need secured context as it's an event initiated by the user.

Only works when an `<input>` tag isn't active.