### PR TITLE
feat(TorrentDetail): Add torrent navigation buttons

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -6,7 +6,7 @@ import Navbar from '@/components/Navbar/Navbar.vue'
 import { TitleOptions } from '@/constants/vuetorrent'
 import { formatPercent, formatSpeed } from '@/helpers'
 import { backend } from '@/services/backend'
-import { useAddTorrentStore, useAppStore, useDialogStore, useLogStore, useMaindataStore, usePreferenceStore, useTorrentStore, useVueTorrentStore } from '@/stores'
+import { useAddTorrentStore, useAppStore, useDialogStore, useGlobalStore, useLogStore, useMaindataStore, usePreferenceStore, useTorrentStore, useVueTorrentStore } from '@/stores'
 import { storeToRefs } from 'pinia'
 import { onBeforeMount, onMounted, watch, watchEffect } from 'vue'
 import { useBackendSync, useI18nUtils } from '@/composables'
@@ -21,6 +21,7 @@ const maindataStore = useMaindataStore()
 const { serverState } = storeToRefs(maindataStore)
 const { torrents } = storeToRefs(useTorrentStore())
 const preferencesStore = usePreferenceStore()
+const { routerDomKey } = storeToRefs(useGlobalStore())
 const vuetorrentStore = useVueTorrentStore()
 const { language, uiTitleCustom, uiTitleType, useBitSpeed } = storeToRefs(vuetorrentStore)
 
@@ -141,7 +142,7 @@ watchEffect(() => {
     <component v-for="dialog in dialogStore.dialogs.values()" :is="dialog.component" v-bind="{ guid: dialog.guid, ...dialog.props }" />
     <Navbar v-if="appStore.isAuthenticated" />
     <v-main>
-      <router-view />
+      <router-view :key="routerDomKey" />
     </v-main>
     <AddPanel v-if="appStore.isAuthenticated" />
     <DnDZone />

--- a/src/pages/TorrentDetail.vue
+++ b/src/pages/TorrentDetail.vue
@@ -36,14 +36,25 @@ const torrent = computed(() => torrentStore.getTorrentByHash(hash.value))
 const isFirstTorrent = computed(() => torrentIndex.value === 0)
 const isLastTorrent = computed(() => torrentIndex.value === torrentStore.processedTorrents.length - 1)
 
-function goToPreviousTorrent() {
-  router.push({ name: 'torrentDetail', params: { hash: torrentStore.processedTorrents[torrentIndex.value - 1].hash } })
+function goToTorrentIndex(index: number) {
+  router.push({ name: 'torrentDetail', params: { hash: torrentStore.processedTorrents[index].hash } })
     .then(res => !res && globalStore.forceReload())
 }
 
+function goToFirstTorrent() {
+  goToTorrentIndex(0)
+}
+
+function goToPreviousTorrent() {
+  goToTorrentIndex(torrentIndex.value - 1)
+}
+
 function goToNextTorrent() {
-  router.push({ name: 'torrentDetail', params: { hash: torrentStore.processedTorrents[torrentIndex.value + 1].hash } })
-    .then(res => !res && globalStore.forceReload())
+  goToTorrentIndex(torrentIndex.value + 1)
+}
+
+function goToLastTorrent() {
+  goToTorrentIndex(torrentStore.processedTorrents.length - 1)
 }
 
 function goHome() {
@@ -96,8 +107,10 @@ onBeforeUnmount(() => {
       </v-col>
       <v-col>
         <div class="d-flex justify-end">
+          <v-btn icon="mdi-skip-previous" :disabled="isFirstTorrent" variant="plain" @click="goToFirstTorrent" />
           <v-btn icon="mdi-arrow-left" :disabled="isFirstTorrent" variant="plain" @click="goToPreviousTorrent" />
           <v-btn icon="mdi-arrow-right" :disabled="isLastTorrent" variant="plain" @click="goToNextTorrent" />
+          <v-btn icon="mdi-skip-next" :disabled="isLastTorrent" variant="plain" @click="goToLastTorrent" />
           <v-btn icon="mdi-close" variant="plain" @click="goHome" />
         </div>
       </v-col>

--- a/src/pages/TorrentDetail.vue
+++ b/src/pages/TorrentDetail.vue
@@ -7,7 +7,7 @@ import Peers from '@/components/TorrentDetail/Peers.vue'
 import TagsAndCategories from '@/components/TorrentDetail/TagsAndCategories.vue'
 import Trackers from '@/components/TorrentDetail/Trackers.vue'
 import { useI18nUtils } from '@/composables'
-import { useContentStore, useDialogStore, useTorrentDetailStore, useTorrentStore } from '@/stores'
+import { useContentStore, useDialogStore, useGlobalStore, useTorrentDetailStore, useTorrentStore } from '@/stores'
 import { storeToRefs } from 'pinia'
 import { computed, onBeforeUnmount, onMounted, watch } from 'vue'
 import { useRouter } from 'vue-router'
@@ -16,6 +16,7 @@ const router = useRouter()
 const { t } = useI18nUtils()
 const contentStore = useContentStore()
 const dialogStore = useDialogStore()
+const globalStore = useGlobalStore()
 const torrentStore = useTorrentStore()
 const torrentDetailStore = useTorrentDetailStore()
 const { tab } = storeToRefs(torrentDetailStore)
@@ -30,9 +31,22 @@ const tabs = [
 ]
 
 const hash = computed(() => router.currentRoute.value.params.hash as string)
+const torrentIndex = computed(() => torrentStore.getTorrentIndexByHash(hash.value))
 const torrent = computed(() => torrentStore.getTorrentByHash(hash.value))
+const isFirstTorrent = computed(() => torrentIndex.value === 0)
+const isLastTorrent = computed(() => torrentIndex.value === torrentStore.processedTorrents.length - 1)
 
-const goHome = () => {
+function goToPreviousTorrent() {
+  router.push({ name: 'torrentDetail', params: { hash: torrentStore.processedTorrents[torrentIndex.value - 1].hash } })
+    .then(res => !res && globalStore.forceReload())
+}
+
+function goToNextTorrent() {
+  router.push({ name: 'torrentDetail', params: { hash: torrentStore.processedTorrents[torrentIndex.value + 1].hash } })
+    .then(res => !res && globalStore.forceReload())
+}
+
+function goHome() {
   router.push({ name: 'dashboard' })
 }
 
@@ -82,6 +96,8 @@ onBeforeUnmount(() => {
       </v-col>
       <v-col>
         <div class="d-flex justify-end">
+          <v-btn icon="mdi-arrow-left" :disabled="isFirstTorrent" variant="plain" @click="goToPreviousTorrent" />
+          <v-btn icon="mdi-arrow-right" :disabled="isLastTorrent" variant="plain" @click="goToNextTorrent" />
           <v-btn icon="mdi-close" variant="plain" @click="goHome" />
         </div>
       </v-col>

--- a/src/stores/global.ts
+++ b/src/stores/global.ts
@@ -1,0 +1,24 @@
+import { useTorrentDetailStore } from '@/stores/torrentDetail.ts'
+import { acceptHMRUpdate, defineStore } from 'pinia'
+import { v4 as uuidv4 } from 'uuid'
+import { ref } from 'vue'
+
+export const useGlobalStore = defineStore('global', () => {
+  const routerDomKey = ref(uuidv4())
+
+  function forceReload() {
+    routerDomKey.value = uuidv4()
+  }
+
+  return {
+    routerDomKey,
+    forceReload,
+    $reset: () => {
+      forceReload()
+    }
+  }
+})
+
+if (import.meta.hot) {
+  import.meta.hot.accept(acceptHMRUpdate(useTorrentDetailStore, import.meta.hot))
+}

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -4,6 +4,7 @@ import { useCategoryStore } from './categories'
 import { useContentStore } from './content'
 import { useDashboardStore } from './dashboard'
 import { useDialogStore } from './dialog'
+import { useGlobalStore } from './global'
 import { useHistoryStore } from './history'
 import { useLogStore } from './logs'
 import { useMaindataStore } from './maindata'
@@ -25,6 +26,7 @@ export {
   useContentStore,
   useDashboardStore,
   useDialogStore,
+  useGlobalStore,
   useHistoryStore,
   useLogStore,
   useMaindataStore,


### PR DESCRIPTION
Fixes #2106

This PR adds 4 buttons to the Torrent Detail view. These buttons' actions are as follows from left to right:
- go to first filtered torrent
- go to previous filtered torrent
- go to next filtered torrent
- go to last filtered torrent

![image](https://github.com/user-attachments/assets/cf597bca-a132-45d0-a361-dfc818ff2c23)

Also a new store has been introduced to allow for remounting the router component and ensure that lifecycle event are properly executed.