### PR TITLE
Feat: Add OLED theme

### DIFF
--- a/src/components/Core/ColoredChip.vue
+++ b/src/components/Core/ColoredChip.vue
@@ -21,18 +21,20 @@ const props = withDefaults(
 const { t } = useI18nUtils()
 const { current } = useTheme()
 const { enableHashColors, hideColoredChip } = storeToRefs(useVueTorrentStore())
+const vueTorrentStore = useVueTorrentStore()
 
 function getThemeColor(color: string) {
   return current.value.colors[color] ?? color
 }
 
-// Darken colors for OLED theme
-const vueTorrentStore = useVueTorrentStore()
-let darkenColors = false
-if (vueTorrentStore.theme.mode === 'dark' && vueTorrentStore.theme.dark === 'dark-oled') darkenColors = true
+function transformColor(color: TinyColor) {
+  if (isDarkOledTheme.value) return color.darken(30)
+  else return color
+}
 
-const chipColor = computed(() => (props.disabled || !enableHashColors.value ? props.defaultColor : getColorFromName(props.value, darkenColors)))
-const rawChipColor = computed(() => (props.disabled || !enableHashColors.value ? getThemeColor(props.defaultColor) : getColorFromName(props.value, darkenColors)))
+const isDarkOledTheme = computed(() => vueTorrentStore.theme.mode === 'dark' && vueTorrentStore.theme.dark === 'dark-oled')
+const chipColor = computed(() => (props.disabled || !enableHashColors.value ? props.defaultColor : getColorFromName(props.value, transformColor)))
+const rawChipColor = computed(() => (props.disabled || !enableHashColors.value ? getThemeColor(props.defaultColor) : getColorFromName(props.value, transformColor)))
 const chipValue = computed(() => (props.disabled ? props.disabledValue || props.value || t('common.none') : props.value))
 const shouldShowColoredChips = computed(() => !hideColoredChip.value)
 </script>

--- a/src/components/Core/ColoredChip.vue
+++ b/src/components/Core/ColoredChip.vue
@@ -26,8 +26,13 @@ function getThemeColor(color: string) {
   return current.value.colors[color] ?? color
 }
 
-const chipColor = computed(() => (props.disabled || !enableHashColors.value ? props.defaultColor : getColorFromName(props.value)))
-const rawChipColor = computed(() => (props.disabled || !enableHashColors.value ? getThemeColor(props.defaultColor) : getColorFromName(props.value)))
+// Darken colors for OLED theme
+const vueTorrentStore = useVueTorrentStore()
+let darkenColors = false
+if (vueTorrentStore.theme.mode === 'dark' && vueTorrentStore.theme.dark === 'dark-oled') darkenColors = true
+
+const chipColor = computed(() => (props.disabled || !enableHashColors.value ? props.defaultColor : getColorFromName(props.value, darkenColors)))
+const rawChipColor = computed(() => (props.disabled || !enableHashColors.value ? getThemeColor(props.defaultColor) : getColorFromName(props.value, darkenColors)))
 const chipValue = computed(() => (props.disabled ? props.disabledValue || props.value || t('common.none') : props.value))
 const shouldShowColoredChips = computed(() => !hideColoredChip.value)
 </script>

--- a/src/components/Core/ColoredChip.vue
+++ b/src/components/Core/ColoredChip.vue
@@ -20,8 +20,8 @@ const props = withDefaults(
 
 const { t } = useI18nUtils()
 const { current } = useTheme()
-const { enableHashColors, hideColoredChip } = storeToRefs(useVueTorrentStore())
 const vueTorrentStore = useVueTorrentStore()
+const { enableHashColors, hideColoredChip } = storeToRefs(vueTorrentStore)
 
 function getThemeColor(color: string) {
   return current.value.colors[color] ?? color

--- a/src/components/Core/ColoredChip.vue
+++ b/src/components/Core/ColoredChip.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
-import { useVueTorrentStore } from '@/stores'
 import { computed } from 'vue'
-import { getColorFromName } from '@/helpers'
-import { useI18nUtils } from '@/composables'
 import { useTheme } from 'vuetify'
+import { useI18nUtils } from '@/composables'
+import { TinyColor } from '@ctrl/tinycolor'
+import { getColorFromName } from '@/helpers'
+import { useVueTorrentStore } from '@/stores'
 
 const props = withDefaults(
   defineProps<{

--- a/src/components/Settings/VueTorrent/General.vue
+++ b/src/components/Settings/VueTorrent/General.vue
@@ -5,7 +5,7 @@ import { openLink } from '@/helpers'
 import { LOCALES } from '@/locales'
 import { Github } from '@/services/Github'
 import { useAppStore, useDialogStore, useHistoryStore, useTorrentStore, useVueTorrentStore } from '@/stores'
-import { DarkLegacy, DarkRedesigned, LightLegacy, LightRedesigned } from '@/themes'
+import { DarkLegacy, DarkRedesigned, DarkOled, LightLegacy, LightRedesigned } from '@/themes'
 import { storeToRefs } from 'pinia'
 import { computed, readonly, ref } from 'vue'
 import { useI18nUtils } from '@/composables'
@@ -39,7 +39,8 @@ const lightVariants = readonly([
 
 const darkVariants = readonly([
   { title: t('constants.themes.dark.legacy'), value: DarkLegacy.id },
-  { title: t('constants.themes.dark.redesigned'), value: DarkRedesigned.id }
+  { title: t('constants.themes.dark.redesigned'), value: DarkRedesigned.id },
+  { title: t('constants.themes.dark.oled'), value: DarkOled.id }
 ])
 
 const paginationSizes = ref([{ title: t('settings.vuetorrent.general.paginationSize.infinite_scroll'), value: -1 }, 5, 15, 30, 50, 100, 250, 500])

--- a/src/helpers/colors.ts
+++ b/src/helpers/colors.ts
@@ -1,5 +1,5 @@
 import { TorrentState } from '@/constants/vuetorrent'
-import { random } from '@ctrl/tinycolor'
+import { TinyColor, random } from '@ctrl/tinycolor'
 
 function djb2Hash(str: string): number {
   let hash = 5381

--- a/src/helpers/colors.ts
+++ b/src/helpers/colors.ts
@@ -9,12 +9,12 @@ function djb2Hash(str: string): number {
   return hash >>> 0 // ensure non-negative integer
 }
 
-export function getColorFromName(name: string, darkenColors?: boolean) {
+export function getColorFromName(name: string, transform?: (color: TinyColor) => TinyColor) {
   const color = random({
     seed: djb2Hash(name)
   })
 
-  if (darkenColors) return color.darken(20).toHexString()
+  if (transform) return transform(color).toHexString()
   else return color.toHexString()
 }
 

--- a/src/helpers/colors.ts
+++ b/src/helpers/colors.ts
@@ -1,5 +1,5 @@
 import { TorrentState } from '@/constants/vuetorrent'
-import { random } from '@ctrl/tinycolor'
+import { random, darken } from '@ctrl/tinycolor'
 
 function djb2Hash(str: string): number {
   let hash = 5381
@@ -9,12 +9,13 @@ function djb2Hash(str: string): number {
   return hash >>> 0 // ensure non-negative integer
 }
 
-export function getColorFromName(name: string) {
+export function getColorFromName(name: string, darkenColors: bool) {
   const color = random({
     seed: djb2Hash(name)
   })
 
-  return color.toHexString()
+  if (darkenColors) return color.darken(20).toHexString()
+  else return color.toHexString()
 }
 
 export function getRatioColor(ratio: number) {

--- a/src/helpers/colors.ts
+++ b/src/helpers/colors.ts
@@ -1,5 +1,5 @@
 import { TorrentState } from '@/constants/vuetorrent'
-import { random, darken } from '@ctrl/tinycolor'
+import { random } from '@ctrl/tinycolor'
 
 function djb2Hash(str: string): number {
   let hash = 5381

--- a/src/helpers/colors.ts
+++ b/src/helpers/colors.ts
@@ -9,7 +9,7 @@ function djb2Hash(str: string): number {
   return hash >>> 0 // ensure non-negative integer
 }
 
-export function getColorFromName(name: string, darkenColors: bool) {
+export function getColorFromName(name: string, darkenColors?: boolean) {
   const color = random({
     seed: djb2Hash(name)
   })

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -116,7 +116,8 @@
     "themes": {
       "dark": {
         "legacy": "Legacy",
-        "redesigned": "Redesigned"
+        "redesigned": "Redesigned",
+        "oled": "OLED"
       },
       "light": {
         "legacy": "Legacy",

--- a/src/themes/dark/oled.ts
+++ b/src/themes/dark/oled.ts
@@ -1,19 +1,15 @@
 import colors from 'vuetify/util/colors'
-import { getVariables } from '../global'
+//import { getVariables } from '../global'
+import DarkLegacy from './legacy'
 
 export default {
   id: 'dark-oled',
   theme: {
     dark: true,
     colors: {
-      primary: '#35495E',
-      secondary: '#415c75',
-      navbar: '#273845',
-      download: '#5BB974',
-      background: '#121212',
-      selected: colors.grey.darken1,
-      red: colors.red.accent3,
-      ...getVariables(true)
+      ...DarkLegacy.theme.colors,
+      'torrent-ul_stalled': colors.blue.darken4,
+      'torrent-uploading': colors.teal.darken2
     }
   }
 }

--- a/src/themes/dark/oled.ts
+++ b/src/themes/dark/oled.ts
@@ -1,5 +1,4 @@
 import colors from 'vuetify/util/colors'
-//import { getVariables } from '../global'
 import DarkLegacy from './legacy'
 
 export default {

--- a/src/themes/dark/oled.ts
+++ b/src/themes/dark/oled.ts
@@ -1,0 +1,19 @@
+import colors from 'vuetify/util/colors'
+import { getVariables } from '../global'
+
+export default {
+  id: 'dark-oled',
+  theme: {
+    dark: true,
+    colors: {
+      primary: '#35495E',
+      secondary: '#415c75',
+      navbar: '#273845',
+      download: '#5BB974',
+      background: '#121212',
+      selected: colors.grey.darken1,
+      red: colors.red.accent3,
+      ...getVariables(true)
+    }
+  }
+}

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -1,10 +1,11 @@
 import { ThemeDefinition } from 'vuetify'
 import DarkRedesigned from './dark/redesigned'
 import DarkLegacy from './dark/legacy'
+import DarkOled from './dark/oled'
 import LightRedesigned from './light/redesigned'
 import LightLegacy from './light/legacy'
 
-const themes = [DarkLegacy, DarkRedesigned, LightLegacy, LightRedesigned]
+const themes = [DarkLegacy, DarkRedesigned, DarkOled, LightLegacy, LightRedesigned]
 
 export default themes.reduce(
   (obj, theme) => {
@@ -14,4 +15,4 @@ export default themes.reduce(
   {} as Record<string, ThemeDefinition>
 )
 
-export { themes, DarkLegacy, DarkRedesigned, LightLegacy, LightRedesigned }
+export { themes, DarkLegacy, DarkRedesigned, DarkOled, LightLegacy, LightRedesigned }


### PR DESCRIPTION
# Add OLED theme [feat]

https://github.com/VueTorrent/VueTorrent/issues/2092

I've imported functionality from `tinycolor` that darkens colors for OLED monitors. I've found that many of the dynamically generated colors for chips and other items are a bit too bright on OLED.

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
