### PR TITLE
fix: Readme markdown note (docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ The sleekest looking WebUI for qBittorrent made with Vue.js!
 
 A live demo **with mocked data** is available here: <https://vuetorrent.github.io/demo>
 
-> [!NOTE] This version isn't connected to a qBittorrent instance.
+> [!NOTE]
+> This version isn't connected to a qBittorrent instance.
 >
 > Don't try to download torrents or change preferences, it won't work 😉
 


### PR DESCRIPTION
# README markdown note [fix]

You have a broken markdown. `[!NOTE]` should be on a separate line in the README.md.

**Before:**

![image](https://github.com/user-attachments/assets/79d2bf55-3113-49cf-a9a7-dec3d8b75c08)

**After:**

![image](https://github.com/user-attachments/assets/36622c78-0281-4cfe-a29f-c575550c90cc)


## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [ ] All tests pass
- [ ] I've removed all commented code
