### PR TITLE
fix(Overview): Use correct selected size

### DIFF
--- a/src/components/TorrentDetail/Overview.vue
+++ b/src/components/TorrentDetail/Overview.vue
@@ -26,6 +26,7 @@ const vuetorrentStore = useVueTorrentStore()
 const isContextSecured = computed(() => window.isSecureContext)
 
 const selectedFiles = computed(() => cachedFiles.value.filter(f => f.priority !== FilePriority.DO_NOT_DOWNLOAD))
+const selectedFilesSize = computed(() => selectedFiles.value.reduce((acc, file) => acc + file.size, 0))
 const torrentFileCount = computed(() => cachedFiles.value.length)
 const torrentFileName = computed(() => (selectedFiles.value.length === 1 ? selectedFiles.value[0].name : ''))
 
@@ -229,7 +230,7 @@ onUnmounted(async () => {
             <v-col cols="6">
               <div>{{ $t('torrentDetail.overview.selectedFileSize') }}:</div>
               <div>
-                {{ formatData(torrent.size, vuetorrentStore.useBinarySize) }} /
+                {{ formatData(selectedFilesSize, vuetorrentStore.useBinarySize) }} /
                 {{ formatData(torrent.total_size, vuetorrentStore.useBinarySize) }}
               </div>
             </v-col>


### PR DESCRIPTION
`torrent.size` returns:
- Either the selected size if files are missing,
- Or downloaded size if all selected files are downloaded
