### PR TITLE
fix(backend): Torrent properties not synced more than once

### DIFF
--- a/src/composables/BackendSync.ts
+++ b/src/composables/BackendSync.ts
@@ -29,7 +29,7 @@ export function useBackendSync(store: Store, key: string, config: { blacklist?: 
       }
     })
     store.$patch(temp)
-    _lastState.value = temp
+    _lastState.value = JSON.parse(JSON.stringify(temp))
   }
 
   async function saveState() {
@@ -43,7 +43,7 @@ export function useBackendSync(store: Store, key: string, config: { blacklist?: 
     if (!isObjectEqual(state, _lastState.value)) {
       const success = await backend.set(key, JSON.stringify(state))
       if (success) {
-        _lastState.value = state
+        _lastState.value = JSON.parse(JSON.stringify(state))
       }
     }
   }


### PR DESCRIPTION
Fixes #2162

e2492aacbbcb2723828fcfb87b17d49afe6214c3 introduced a bug where a previous value would keep object references. It wouldn't trigger the update afterwards because `_lastState` object kept the reference to the new value, thus always returning true when comparing old and new state values.