### PR TITLE
chore(deps): Rollback @vue/eslint-config-typescript to 14.2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,3 +36,6 @@ jobs:
 
       - name: Test Build
         run: npm run build
+
+      - name: Test lint
+        run: npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "@typescript-eslint/parser": "^8.22.0",
         "@vitejs/plugin-vue": "^5.2.1",
         "@vitest/coverage-v8": "^3.0.5",
-        "@vue/eslint-config-typescript": "^14.3.0",
+        "@vue/eslint-config-typescript": "^14.2.0",
         "@vue/test-utils": "^2.4.6",
         "eslint": "^9.17.0",
         "eslint-config-prettier": "^10.0.1",
@@ -2852,15 +2852,14 @@
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g=="
     },
     "node_modules/@vue/eslint-config-typescript": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/@vue/eslint-config-typescript/-/eslint-config-typescript-14.3.0.tgz",
-      "integrity": "sha512-bOreIxlSC/xsUdhDdKIHb1grwJah+IokNeJ50LqA1StdOHeSPUxSIPNxyKgRx4YdjhyzC6TKtrCf6yYK99x3Uw==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@vue/eslint-config-typescript/-/eslint-config-typescript-14.2.0.tgz",
+      "integrity": "sha512-JJ4wHuTJa2faQsBOUeWzuHOSFizVS7RWG2eH2noABk2LcT4wVcTOMZKM/lFobKBcgwADIPAKVRGFHVKooXImoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/utils": "^8.20.0",
-        "fast-glob": "^3.3.3",
-        "typescript-eslint": "^8.20.0",
+        "fast-glob": "^3.3.2",
+        "typescript-eslint": "^8.18.1",
         "vue-eslint-parser": "^9.4.3"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@typescript-eslint/parser": "^8.22.0",
     "@vitejs/plugin-vue": "^5.2.1",
     "@vitest/coverage-v8": "^3.0.5",
-    "@vue/eslint-config-typescript": "^14.3.0",
+    "@vue/eslint-config-typescript": "^14.2.0",
     "@vue/test-utils": "^2.4.6",
     "eslint": "^9.17.0",
     "eslint-config-prettier": "^10.0.1",


### PR DESCRIPTION
Bump caused lint command to fail