### PR TITLE
option to collapse/expand content items by default closes #2159

### DIFF
--- a/src/components/Settings/VueTorrent/General.vue
+++ b/src/components/Settings/VueTorrent/General.vue
@@ -80,7 +80,9 @@ const paginationSize = computed({
   }
 })
 
-const paginationSizeMessages = computed(() => (vueTorrentStore.paginationSize === -1 || vueTorrentStore.paginationSize >= 250 ? t('settings.vuetorrent.general.paginationSize.warning') : ''))
+const paginationSizeMessages = computed(() =>
+  vueTorrentStore.paginationSize === -1 || vueTorrentStore.paginationSize >= 250 ? t('settings.vuetorrent.general.paginationSize.warning') : ''
+)
 
 const resetSettings = () => {
   localStorage.clear()
@@ -201,6 +203,9 @@ function openDurationFormatHelp() {
         </v-col>
         <v-col cols="12" sm="6">
           <v-checkbox v-model="vueTorrentStore.useBitSpeed" hide-details density="compact" :label="t('settings.vuetorrent.general.useBitSpeed')" />
+        </v-col>
+        <v-col cols="12" sm="6">
+          <v-checkbox v-model="vueTorrentStore.expandContent" hide-details density="compact" :label="t('settings.vuetorrent.general.expandContent')" />
         </v-col>
       </v-row>
     </v-list-item>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1062,6 +1062,7 @@
         "durationFormat": "Duration format",
         "enableHashColors": "Enable generated chip colors",
         "enableRatioColors": "Enable ratio colors",
+        "expandContent": "Expand content by default in Content view",
         "fetchExternalIpInfo": "Fetch external IP info",
         "fileContentInterval": "Torrent file content refresh interval",
         "filterType": "Filters inclusion type",

--- a/src/stores/content.ts
+++ b/src/stores/content.ts
@@ -15,7 +15,7 @@ export const useContentStore = defineStore('content', () => {
   const { t } = useI18nUtils()
   const route = useRoute()
   const dialogStore = useDialogStore()
-  const { fileContentInterval } = storeToRefs(useVueTorrentStore())
+  const { fileContentInterval, expandContent } = storeToRefs(useVueTorrentStore())
 
   const hash = computed(() => route.params.hash as string)
 
@@ -99,7 +99,7 @@ export const useContentStore = defineStore('content', () => {
 
   const updateFileTreeTask = useTask(function* () {
     if (isFirstRun.value) {
-      yield updateFileTree().then(() => expandAll())
+      yield updateFileTree().then(() => expandContent.value && expandAll())
       isFirstRun.value = false
     } else {
       yield updateFileTree()

--- a/src/stores/vuetorrent.ts
+++ b/src/stores/vuetorrent.ts
@@ -45,6 +45,7 @@ export const useVueTorrentStore = defineStore(
     const durationFormat = ref(defaultDurationFormat)
     const isShutdownButtonVisible = ref(false)
     const useBitSpeed = ref(false)
+    const expandContent = ref(true)
     const useBinarySize = ref(false)
     const refreshInterval = ref(2000)
     const fileContentInterval = ref(5000)
@@ -283,6 +284,7 @@ export const useVueTorrentStore = defineStore(
       toggleBusyGridProperty,
       toggleDoneGridProperty,
       toggleTableProperty,
+      expandContent,
       $reset: () => {
         language.value = 'en'
         theme.mode = ThemeMode.SYSTEM
@@ -314,6 +316,7 @@ export const useVueTorrentStore = defineStore(
         displayGraphLimits.value = true
         useEmojiState.value = true
         fetchExternalIpInfo.value = false
+        expandContent.value = true
 
         _busyProperties.value = JSON.parse(JSON.stringify(propsData))
         _doneProperties.value = JSON.parse(JSON.stringify(propsData))


### PR DESCRIPTION
# option to collapse/expand content items by default [feat]

as discussed in #2159 and #2155, This PR introduces  a feature to toggle expand/collapse of content tab items by default.

this toggle can be set from General settings  `Expand content by default`
![Screenshot From 2025-02-22 14-39-59](https://github.com/user-attachments/assets/2339037f-b9be-48b6-9093-39bdb846ac52)

proof of testing:
https://github.com/user-attachments/assets/3e7966b2-628b-478d-b07f-0e804f9c7360



## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
