### PR TITLE
settings: speed: upload and download limits are kilobytes, not kibibytes

### DIFF
--- a/src/components/Settings/Speed.vue
+++ b/src/components/Settings/Speed.vue
@@ -48,10 +48,10 @@ const altDlLimit = computed({
 
           <v-row class="mx-1">
             <v-col cols="12" md="6">
-              <v-text-field v-model="upLimit" hide-details suffix="kiB/s" :label="t('settings.speed.upload')" />
+              <v-text-field v-model="upLimit" hide-details suffix="kB/s" :label="t('settings.speed.upload')" />
             </v-col>
             <v-col cols="12" md="6">
-              <v-text-field v-model="dlLimit" hide-details suffix="kiB/s" :label="t('settings.speed.download')" />
+              <v-text-field v-model="dlLimit" hide-details suffix="kB/s" :label="t('settings.speed.download')" />
             </v-col>
           </v-row>
 
@@ -67,10 +67,10 @@ const altDlLimit = computed({
 
           <v-row class="mx-1">
             <v-col cols="12" md="6">
-              <v-text-field v-model="altUpLimit" hide-details suffix="kiB/s" :label="t('settings.speed.upload')" />
+              <v-text-field v-model="altUpLimit" hide-details suffix="kB/s" :label="t('settings.speed.upload')" />
             </v-col>
             <v-col cols="12" md="6">
-              <v-text-field v-model="altDlLimit" hide-details suffix="kiB/s" :label="t('settings.speed.download')" />
+              <v-text-field v-model="altDlLimit" hide-details suffix="kB/s" :label="t('settings.speed.download')" />
             </v-col>
           </v-row>
 


### PR DESCRIPTION
# Fix units in speed limits settings [chore]

The global and alternative speed limits in qBittorrent are in kB/s. The right-click dialog for setting per-torrent speed limits reflect that, but the speed limits in the settings "page" don't. This PR corrects the units from kibibytes to kilobytes.

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
