### PR TITLE
feat(filter): makes it easy to filter torrents with accents

### DIFF
--- a/src/composables/SearchQuery.ts
+++ b/src/composables/SearchQuery.ts
@@ -1,4 +1,5 @@
 import { computed, MaybeRefOrGetter, toValue } from 'vue'
+import { normalize } from '@/helpers/text.ts'
 
 export function useSearchQuery<T>(
   items: MaybeRefOrGetter<T[]>,
@@ -8,7 +9,10 @@ export function useSearchQuery<T>(
 ) {
   const results = computed(() => {
     const searchItems = toValue(items) ?? []
-    const tokens = (toValue(searchQuery) ?? '').trim().toLowerCase().split(/[ ,]/i).filter(Boolean)
+    const tokens = normalize(toValue(searchQuery) ?? '')
+      .trim()
+      .split(/[ ,]/i)
+      .filter(Boolean)
     const inclusionTokens = tokens.filter(token => !token.startsWith('-'))
     const exclusionTokens = tokens.filter(token => token.startsWith('-')).map(token => token.slice(1))
     const res = searchItems.filter(item => handleIncludeTokens(item, inclusionTokens) && handleExcludeTokens(item, exclusionTokens))
@@ -19,7 +23,7 @@ export function useSearchQuery<T>(
     return tokens.every(token => {
       let value = getter(item)
       if (!Array.isArray(value)) value = [value]
-      return value.some(v => v.toLowerCase().indexOf(token) !== -1)
+      return value.some(v => normalize(v).indexOf(token) !== -1)
     })
   }
 
@@ -27,7 +31,7 @@ export function useSearchQuery<T>(
     return !tokens.some(token => {
       let value = getter(item)
       if (!Array.isArray(value)) value = [value]
-      return value.some(v => v.toLowerCase().indexOf(token) !== -1)
+      return value.some(v => normalize(v).indexOf(token) !== -1)
     })
   }
 

--- a/src/helpers/text.spec.ts
+++ b/src/helpers/text.spec.ts
@@ -1,4 +1,4 @@
-import { capitalize, codeToFlag, extractHostname, getDomainBody, splitByUrl, containsUrl, titleCase, isValidUri } from './text'
+import { capitalize, codeToFlag, extractHostname, getDomainBody, splitByUrl, containsUrl, titleCase, isValidUri, normalize } from './text'
 import { expect, test } from 'vitest'
 
 test('helpers/text/titleCase', () => {
@@ -119,4 +119,10 @@ test('helpers/text/codeToFlag', () => {
 
   expect(codeToFlag('it').char).toBe('🇮🇹')
   expect(codeToFlag('it').url).toBe('https://cdn.jsdelivr.net/npm/twemoji/2/svg/1f1ee-1f1f9.svg')
+})
+
+test('helpers/text/normalize', () => {
+  expect(normalize('crème brûlée')).toBe('creme brulee')
+  expect(normalize('ąśćńżóźćęç')).toBe('ascnzozcec')
+  expect(normalize('áéíóú ÁÉÍÓÚ üÜ')).toBe('aeiou aeiou uu')
 })

--- a/src/helpers/text.ts
+++ b/src/helpers/text.ts
@@ -104,3 +104,10 @@ export function codeToFlag(code: string) {
     url
   }
 }
+
+export function normalize(data: string) {
+  return data
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+}


### PR DESCRIPTION
# Accent/diacritics insensitive filter [feat]

If there is a torrent called for example "dragón", if you search for "dragon" it will also find it.

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
