### PR TITLE
fix(i18n): Use correct pluralizations for torrent counts

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -272,12 +272,12 @@
     },
     "searchInputLabel": "Search",
     "selectAll": "(Un)select All (Ctrl + A)",
-    "selectedTorrentsCount": "No torrent | {count} of {total} torrent ({size}) | {count} of {total} torrents ({size})",
+    "selectedTorrentsCount": "No torrents | {count} of {total} torrents ({size}) | {count} of {total} torrents ({size})",
     "sortLabel": "Sort by",
     "toggleSearchFilter": "Toggle search filter",
     "toggleSelectMode": "Toggle select mode",
     "toggleSortOrder": "Reverse sort order",
-    "torrentsCount": "No torrent | {n} torrent | {n} torrents"
+    "torrentsCount": "No torrents | {n} torrent | {n} torrents"
   },
   "dialogs": {
     "add": {


### PR DESCRIPTION
Updated `selectedTorrentsCount` and `torrentsCount` strings in `en.json` to use correct plural forms.

The pluralizing is currently grammatically incorrect, it uses the `count` value instead of the `total` value to pluralize `torrent`, but _at least in English,_ it's fine to say `1 of 1 torrents`.

Before:

<img width="215" height="47" alt="image" src="https://github.com/user-attachments/assets/a5421671-28d2-4b3d-94a0-99430b222fab" />

---

After:

<img width="200" height="45" alt="image" src="https://github.com/user-attachments/assets/b9befb13-c507-41f2-b41a-5b0f86dfdd24" />

---

Also, `No torrent` -> `No torrents`



## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
