### PR TITLE
Add per-file piece breakdown

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1424,6 +1424,8 @@
       "piece_canvas_dialog": {
         "title": "Piece state overview",
         "split_by_file": "Split by file",
+        "expand_all": "Expand All",
+        "collapse_all": "Collapse All",
         "piece_tooltip": "Piece #{index} ({state})",
         "piece_states": {
           "missing": "Missing",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1422,7 +1422,14 @@
       "fetchingMetadata": "Fetching...",
       "fileCount": "Selected Files",
       "piece_canvas_dialog": {
-        "title": "Piece state oveview"
+        "title": "Piece state overview",
+        "split_by_file": "Split by file",
+        "piece_tooltip": "Piece #{index} ({state})",
+        "piece_states": {
+          "missing": "Missing",
+          "downloading": "Downloading",
+          "downloaded": "Downloaded"
+        }
       },
       "pieceCount": "{owned} / {total} ({pieceSize})",
       "ratio": "Ratio",

--- a/src/stores/vuetorrent.ts
+++ b/src/stores/vuetorrent.ts
@@ -52,6 +52,7 @@ export const useVueTorrentStore = defineStore(
     const reduceMotion = ref(false)
     const keepDefaultTransitions = computed(() => !reduceMotion.value)
     const defaultTorrentDetailTab = ref(TorrentDetailTab.LAST_OPENED)
+    const piecesViewSplitByFile = ref(false)
 
     const _busyProperties = ref<PropertyData>(JSON.parse(JSON.stringify(propsData)))
     const _doneProperties = ref<PropertyData>(JSON.parse(JSON.stringify(propsData)))
@@ -280,6 +281,7 @@ export const useVueTorrentStore = defineStore(
       reduceMotion,
       keepDefaultTransitions,
       defaultTorrentDetailTab,
+      piecesViewSplitByFile,
       $reset: () => {
         language.value = 'en'
         theme.mode = ThemeMode.SYSTEM
@@ -308,6 +310,7 @@ export const useVueTorrentStore = defineStore(
         expandContent.value = true
         reduceMotion.value = false
         defaultTorrentDetailTab.value = TorrentDetailTab.LAST_OPENED
+        piecesViewSplitByFile.value = false
 
         _busyProperties.value = JSON.parse(JSON.stringify(propsData))
         _doneProperties.value = JSON.parse(JSON.stringify(propsData))


### PR DESCRIPTION
# Add per-file piece breakdown

- Added "Split by file" toggle to piece canvas that shows which pieces belong to which files
- In split view, displays each file with its corresponding pieces and progress
- Uses existing `piece_range` data from qBittorrent API (no additional API calls)
- Also fixes a small typo I've been meaning to fix for a while (`Piece state oveview` to `Piece state overview`)

Note: I've temporarily modified the translation file, but have requested access to Tolgee.

<img width="1311" height="514" alt="image" src="https://github.com/user-attachments/assets/4780be12-8aa1-4e50-93ec-7fa35092013c" />

<img width="1315" height="649" alt="image" src="https://github.com/user-attachments/assets/c230716e-10d6-44df-9bca-86ac6629401b" />


## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Split by File" view mode for piece canvas, allowing users to view pieces grouped by file with search functionality
  * Added expandable/collapsible file sections displaying piece ranges with color-coded state indicators
  * Added per-piece state tooltips and expand/collapse all controls for easier navigation

* **Bug Fixes**
  * Fixed typo in piece state overview dialog title

<!-- end of auto-generated comment: release notes by coderabbit.ai -->