### PR TITLE
feat: add connection stats in sidebar

### DIFF
--- a/src/components/Navbar/SideWidgets/ConnectionStats.vue
+++ b/src/components/Navbar/SideWidgets/ConnectionStats.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import StringCard from './Cards/StringCard.vue'
+import StatSection from './StatSection.vue'
+import { useI18nUtils } from '@/composables'
+import { useMaindataStore } from '@/stores'
+
+const { t } = useI18nUtils()
+const maindataStore = useMaindataStore()
+</script>
+
+<template>
+  <StatSection columns="2">
+    <StringCard
+      orientation="row"
+      :title="t('navbar.side.connection_stats.dht_nodes_connected')"
+      :value="maindataStore.serverState?.dht_nodes ?? 0"
+      color=""
+      icon="mdi-server-network-outline" />
+    <StringCard
+      orientation="row"
+      :title="t('navbar.side.connection_stats.total_peers_connections')"
+      :value="maindataStore.serverState?.total_peer_connections ?? 0"
+      color=""
+      icon="mdi-connection" />
+  </StatSection>
+</template>

--- a/src/components/Navbar/Sidebar.vue
+++ b/src/components/Navbar/Sidebar.vue
@@ -10,6 +10,7 @@ const SpeedGraph = defineAsyncComponent(() => import('./SideWidgets/SpeedGraph.v
 const TransferStats = defineAsyncComponent(() => import('./SideWidgets/TransferStats.vue'))
 const FreeSpace = defineAsyncComponent(() => import('./SideWidgets/FreeSpace.vue'))
 const PerformanceStats = defineAsyncComponent(() => import('./SideWidgets/PerformanceStats.vue'))
+const ConnectionStats = defineAsyncComponent(() => import('./SideWidgets/ConnectionStats.vue'))
 const Filters = defineAsyncComponent(() => import('./SideWidgets/Filters.vue'))
 
 const dashboardStore = useDashboardStore()
@@ -22,6 +23,7 @@ const components: Record<string, Component> = {
   TransferStats,
   FreeSpace,
   PerformanceStats,
+  ConnectionStats,
   Filters,
 }
 

--- a/src/components/Settings/VueTorrent/SidebarItem.vue
+++ b/src/components/Settings/VueTorrent/SidebarItem.vue
@@ -1,11 +1,9 @@
 <script setup lang="ts">
-import { TorrentProperty } from '@/constants/vuetorrent'
-import { useAppStore } from '@/stores'
+import type { SidebarWidget } from '@/types/vuetorrent'
 
-defineProps<{ i18nPrefix: string; property: TorrentProperty }>()
+defineProps<{ i18nPrefix: string; property: SidebarWidget }>()
 defineEmits<{ update: [value: void] }>()
 
-const appStore = useAppStore()
 </script>
 
 <template>
@@ -15,7 +13,6 @@ const appStore = useAppStore()
     </td>
     <td>
       <v-btn
-        :disabled="!appStore.isFeatureAvailable(property.qbitVersion)"
         density="compact"
         :icon="property.active ? 'mdi-checkbox-marked' : 'mdi-checkbox-blank-outline'"
         variant="text"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -648,6 +648,10 @@
         "free_space_on_disk": "Free space for default save path",
         "global_ratio": "Global ratio"
       },
+      "connection_stats": {
+        "dht_nodes_connected": "DHT nodes",
+        "total_peers_connections": "Active peer connections"
+      },
       "performance_stats": {
         "average_time_queue": "Average time in queue",
         "queued_io_jobs": "IO jobs in queue (Checking / Moving / Content rename)",
@@ -1209,6 +1213,7 @@
       },
       "sidebar": {
         "CurrentSpeed": "Show Current Speed",
+        "ConnectionStats": "Show Connection Stats",
         "Filters": "Show Filters",
         "FreeSpace": "Show Free Space",
         "isDrawerRight": "Right Drawer",

--- a/src/stores/sidebar.ts
+++ b/src/stores/sidebar.ts
@@ -18,6 +18,7 @@ export const useSidebarStore = defineStore(
       { name: 'TransferStats', active: true },
       { name: 'FreeSpace', active: true },
       { name: 'PerformanceStats', active: true },
+      { name: 'ConnectionStats', active: true },
       { name: 'Filters', active: true },
     ])
     const isDrawerRight = ref(false)
@@ -66,6 +67,7 @@ export const useSidebarStore = defineStore(
           { name: 'TransferStats', active: true },
           { name: 'FreeSpace', active: true },
           { name: 'PerformanceStats', active: true },
+          { name: 'ConnectionStats', active: true },
           { name: 'Filters', active: true },
         ]
         isDrawerRight.value = false

--- a/src/types/vuetorrent/SidebarWidget.ts
+++ b/src/types/vuetorrent/SidebarWidget.ts
@@ -1,4 +1,4 @@
-type WidgetName = 'CurrentSpeed' | 'SpeedGraph' | 'TransferStats' | 'FreeSpace' | 'PerformanceStats' | 'Filters'
+type WidgetName = 'CurrentSpeed' | 'SpeedGraph' | 'TransferStats' | 'FreeSpace' | 'PerformanceStats' | 'ConnectionStats' | 'Filters'
 
 export default interface SidebarWidget {
   name: WidgetName


### PR DESCRIPTION
# add connection stats in sidebar [feat]

added connection stats in sidebar. used the icons i felt appropriate for the stat. feel free to make change for icon if needed.

<img width="531" height="807" alt="Screenshot 2026-05-11 at 1 16 07 PM" src="https://github.com/user-attachments/assets/c4f81d36-2242-452a-827a-90c30d32f0bf" />

closes #2733

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
