### PR TITLE
feat(Torrent): add share limit action support

### DIFF
--- a/src/components/Dialogs/ShareLimitDialog.vue
+++ b/src/components/Dialogs/ShareLimitDialog.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { computed, onBeforeMount, ref } from 'vue'
-import { useDialog } from '@/composables'
+import { useDialog, useI18nUtils } from '@/composables'
 import { useMaindataStore, useTorrentStore } from '@/stores'
+import { ShareLimitAction } from '@/constants/qbit/AppPreferences'
 
 type ShareType = 'global' | 'disabled' | 'enabled'
 const GLOBAL = -2
@@ -13,6 +14,7 @@ const props = defineProps<{
 }>()
 
 const { isOpened } = useDialog(props.guid)
+const { t } = useI18nUtils()
 const maindataStore = useMaindataStore()
 const torrentStore = useTorrentStore()
 
@@ -29,7 +31,17 @@ const seedingTimeLimit = ref(0)
 const inactiveSeedingTimeLimitEnabled = ref(false)
 const inactiveSeedingTimeLimit = ref(0)
 
+const shareLimitAction = ref<ShareLimitAction>(ShareLimitAction.DEFAULT)
+
 const isFieldsDisabled = computed(() => shareType.value !== 'enabled')
+
+const shareLimitActions = computed(() => [
+  { title: t('dialogs.share_limit.actions.default'), value: ShareLimitAction.DEFAULT },
+  { title: t('dialogs.share_limit.actions.pause'), value: ShareLimitAction.STOP_TORRENT },
+  { title: t('dialogs.share_limit.actions.remove'), value: ShareLimitAction.REMOVE_TORRENT },
+  { title: t('dialogs.share_limit.actions.remove_files'), value: ShareLimitAction.REMOVE_TORRENT_AND_FILES },
+  { title: t('dialogs.share_limit.actions.enable_super_seeding'), value: ShareLimitAction.ENABLE_SUPERSEEDING },
+])
 
 function close() {
   isOpened.value = false
@@ -38,17 +50,18 @@ function close() {
 async function submit() {
   switch (shareType.value) {
     case 'global':
-      await maindataStore.setShareLimit(props.hashes, GLOBAL, GLOBAL, GLOBAL)
+      await maindataStore.setShareLimit(props.hashes, GLOBAL, GLOBAL, GLOBAL, ShareLimitAction.DEFAULT)
       break
     case 'disabled':
-      await maindataStore.setShareLimit(props.hashes, DISABLED, DISABLED, DISABLED)
+      await maindataStore.setShareLimit(props.hashes, DISABLED, DISABLED, DISABLED, ShareLimitAction.DEFAULT)
       break
     case 'enabled':
       await maindataStore.setShareLimit(
         props.hashes,
         ratioLimitEnabled.value ? ratioLimit.value : DISABLED,
         seedingTimeLimitEnabled.value ? seedingTimeLimit.value : DISABLED,
-        inactiveSeedingTimeLimitEnabled.value ? inactiveSeedingTimeLimit.value : DISABLED
+        inactiveSeedingTimeLimitEnabled.value ? inactiveSeedingTimeLimit.value : DISABLED,
+        shareLimitAction.value
       )
       break
   }
@@ -64,6 +77,7 @@ onBeforeMount(() => {
   const ratio_limit = torrent.ratio_limit
   const seeding_time_limit = torrent.seeding_time_limit
   const inactive_seeding_time_limit = torrent.inactive_seeding_time_limit
+  shareLimitAction.value = torrent.share_limit_action ?? ShareLimitAction.DEFAULT
 
   if (ratio_limit === GLOBAL && seeding_time_limit === GLOBAL && inactive_seeding_time_limit === GLOBAL) {
     shareType.value = 'global'
@@ -116,6 +130,15 @@ onBeforeMount(() => {
                 density="compact"
                 hide-details
                 :label="$t('dialogs.share_limit.inactive_seeding_time_limit')" />
+            </v-col>
+            <v-col cols="12">
+              <v-select
+                v-model="shareLimitAction"
+                :items="shareLimitActions"
+                :disabled="isFieldsDisabled"
+                density="compact"
+                hide-details
+                :label="$t('dialogs.share_limit.action')" />
             </v-col>
           </v-row>
         </v-form>

--- a/src/constants/qbit/AppPreferences.ts
+++ b/src/constants/qbit/AppPreferences.ts
@@ -35,11 +35,11 @@ export enum FileLogAgeType {
 }
 
 export enum ShareLimitAction {
-  DEFAULT = -1,
-  STOP_TORRENT = 0,
-  REMOVE_TORRENT = 1,
-  ENABLE_SUPERSEEDING = 2,
-  REMOVE_TORRENT_AND_FILES = 3,
+  DEFAULT = 'Default',
+  STOP_TORRENT = 'Stop',
+  REMOVE_TORRENT = 'Remove',
+  REMOVE_TORRENT_AND_FILES = 'RemoveWithContent',
+  ENABLE_SUPERSEEDING = 'EnableSuperSeeding',
 }
 
 export enum ProxyType {

--- a/src/constants/qbit/index.ts
+++ b/src/constants/qbit/index.ts
@@ -25,3 +25,4 @@ export {
   TorrentOperatingMode,
   TorrentState,
 }
+export { ShareLimitAction } from './AppPreferences'

--- a/src/constants/vuetorrent/Comparators.ts
+++ b/src/constants/vuetorrent/Comparators.ts
@@ -54,6 +54,7 @@ const comparatorMap: Record<keyof Torrent, (a: Torrent, b: Torrent, isAsc: boole
   savePath: (a, b, isAsc) => comparators.textWithNumbers.compare(a.savePath, b.savePath, isAsc),
   seeding_time: (a, b, isAsc) => comparators.numeric.compare(a.seeding_time, b.seeding_time, isAsc),
   seeding_time_limit: (a, b, isAsc) => comparators.numeric.compare(a.seeding_time_limit, b.seeding_time_limit, isAsc),
+  share_limit_action: (a, b, isAsc) => comparators.text.compare(a.share_limit_action || '', b.share_limit_action || '', isAsc),
   seen_complete: (a, b, isAsc) => comparators.numeric.compare(a.seen_complete, b.seen_complete, isAsc),
   seq_dl: (a, b, isAsc) => comparators.boolean.compare(a.seq_dl, b.seq_dl, isAsc),
   size: (a, b, isAsc) => comparators.numeric.compare(a.size, b.size, isAsc),

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -513,6 +513,14 @@
       "inactive_seeding_time_limit": "Inactive minutes",
       "ratio_limit": "Ratio",
       "seeding_time_limit": "Total minutes",
+      "action": "Action when limit reached",
+      "actions": {
+        "default": "Use global setting",
+        "pause": "Stop torrent",
+        "remove": "Remove torrent",
+        "remove_files": "Remove torrent and its files",
+        "enable_super_seeding": "Enable super seeding"
+      },
       "title": "Set share ratio limit"
     },
     "shutdown": {

--- a/src/services/qbit/IProvider.ts
+++ b/src/services/qbit/IProvider.ts
@@ -24,6 +24,8 @@ import { NetworkInterface } from '@/types/qbit/models/AppPreferences'
 import { AddTorrentPayload, AppPreferencesPayload, CreateFeedPayload, GetTorrentPayload, LoginPayload } from '@/types/qbit/payloads'
 import { MaindataResponse, SearchResultsResponse, TorrentPeersResponse } from '@/types/qbit/responses'
 
+import { ShareLimitAction } from '@/constants/qbit/AppPreferences'
+
 export default interface IProvider {
   /// AppController ///
 
@@ -483,7 +485,7 @@ export default interface IProvider {
    * @param seedingTimeLimit Seeding time limit
    * @param inactiveSeedingTimeLimit Inactive seeding time limit
    */
-  setShareLimit(hashes: string[], ratioLimit: number, seedingTimeLimit: number, inactiveSeedingTimeLimit: number): Promise<void>
+  setShareLimit(hashes: string[], ratioLimit: number, seedingTimeLimit: number, inactiveSeedingTimeLimit: number, shareLimitAction: ShareLimitAction): Promise<void>
 
   /**
    * Reannounce torrents

--- a/src/services/qbit/MockProvider.ts
+++ b/src/services/qbit/MockProvider.ts
@@ -7,6 +7,7 @@ import {
   FilePriority,
   LogType,
   PieceState,
+  ShareLimitAction,
   TorrentCreatorTaskStatus,
   TorrentFormat,
   TorrentOperatingMode,
@@ -312,7 +313,7 @@ export default class MockProvider implements IProvider {
         max_inactive_seeding_time: -1,
         max_inactive_seeding_time_enabled: false,
         max_ratio: -1,
-        max_ratio_act: 0,
+        max_ratio_act: ShareLimitAction.STOP_TORRENT,
         max_ratio_enabled: false,
         max_seeding_time: -1,
         max_seeding_time_enabled: false,
@@ -1598,7 +1599,7 @@ export default class MockProvider implements IProvider {
     return this.generateResponse({ result: MockProvider.hashes.length })
   }
 
-  async setShareLimit(_0: string[], _1: number, _2: number, _3: number): Promise<void> {
+  async setShareLimit(_hashes: string[], _ratioLimit: number, _seedingTimeLimit: number, _inactiveSeedingTimeLimit: number, _shareLimitAction: ShareLimitAction): Promise<void> {
     return this.generateResponse()
   }
 

--- a/src/services/qbit/QbitProvider.ts
+++ b/src/services/qbit/QbitProvider.ts
@@ -2,7 +2,7 @@ import type { AxiosInstance, AxiosRequestConfig } from 'axios'
 import axios, { AxiosResponse } from 'axios'
 import type IProvider from './IProvider'
 import type { FilePriority } from '@/constants/qbit'
-import { DirectoryContentMode, LogType, PieceState } from '@/constants/qbit'
+import { DirectoryContentMode, LogType, PieceState, ShareLimitAction } from '@/constants/qbit'
 import type {
   ApplicationVersion,
   AppPreferences,
@@ -586,12 +586,13 @@ export default class QBitProvider implements IProvider {
     return this.axios.get('/torrents/count').then(res => res.data)
   }
 
-  async setShareLimit(hashes: string[], ratioLimit: number, seedingTimeLimit: number, inactiveSeedingTimeLimit: number): Promise<void> {
+  async setShareLimit(hashes: string[], ratioLimit: number, seedingTimeLimit: number, inactiveSeedingTimeLimit: number, shareLimitAction: ShareLimitAction): Promise<void> {
     return this.post(`/torrents/setShareLimits`, {
       hashes: hashes.join('|'),
       ratioLimit,
       seedingTimeLimit,
       inactiveSeedingTimeLimit,
+      shareLimitAction,
     }).then(res => res.data)
   }
 

--- a/src/stores/maindata.ts
+++ b/src/stores/maindata.ts
@@ -14,6 +14,8 @@ import qbit from '@/services/qbit'
 import { ServerState } from '@/types/qbit/models'
 import { isFullUpdate } from '@/types/qbit/responses'
 
+import { ShareLimitAction } from '@/constants/qbit/AppPreferences'
+
 export const useMaindataStore = defineStore('maindata', () => {
   const rid = ref<number>()
   const serverState = shallowRef<Partial<ServerState>>()
@@ -109,8 +111,8 @@ export const useMaindataStore = defineStore('maindata', () => {
     return await qbit.setUploadLimit(hashes, limit)
   }
 
-  async function setShareLimit(hashes: string[], ratioLimit: number, seedingTimeLimit: number, inactiveSeedingTimeLimit: number) {
-    return await qbit.setShareLimit(hashes, ratioLimit, seedingTimeLimit, inactiveSeedingTimeLimit)
+  async function setShareLimit(hashes: string[], ratioLimit: number, seedingTimeLimit: number, inactiveSeedingTimeLimit: number, shareLimitAction: ShareLimitAction) {
+    return await qbit.setShareLimit(hashes, ratioLimit, seedingTimeLimit, inactiveSeedingTimeLimit, shareLimitAction)
   }
 
   return {

--- a/src/types/qbit/models/Torrent.ts
+++ b/src/types/qbit/models/Torrent.ts
@@ -1,4 +1,5 @@
 import type { TorrentState } from '@/constants/qbit'
+import { ShareLimitAction } from '@/constants/qbit/AppPreferences'
 
 export interface RawTorrent {
   /** Time (Unix Epoch) when the torrent was added to the client */
@@ -48,6 +49,11 @@ export interface RawTorrent {
   infohash_v1: string
   /** Torrent SHA256 Hash (only in LibTorrent v2) */
   infohash_v2: string
+  /**
+   * Action to take when share limits are reached
+   * @since 5.2.0
+   */
+  share_limit_action?: ShareLimitAction
   /** Last time (Unix Epoch) when a chunk was downloaded/uploaded */
   last_activity: number
   /** Magnet URI corresponding to this torrent */

--- a/src/types/vuetorrent/Torrent.ts
+++ b/src/types/vuetorrent/Torrent.ts
@@ -1,4 +1,5 @@
 import { TorrentState } from '@/constants/vuetorrent/TorrentState'
+import { ShareLimitAction } from '@/constants/qbit/AppPreferences'
 
 export default interface Torrent {
   added_on: number
@@ -30,6 +31,8 @@ export default interface Torrent {
   hasMetadata: boolean
   hash: string
   inactive_seeding_time_limit: number
+  /** @since 5.2.0 */
+  share_limit_action?: ShareLimitAction
   infohash_v1: string
   infohash_v2: string
   last_activity: number


### PR DESCRIPTION
This pull request adds support for the shareLimitAction parameter in the setShareLimits API call.

### Changes:
- Added share_limit_action to Torrent models.
- Updated setShareLimit to accept and send shareLimitAction.
- Added a dropdown to the Share Limit dialog to allow users to choose the action (Pause, Remove, or Remove torrent and files).
- Defaults to 'Use global setting' for compatibility and to fix the HTTP 400 error on qBittorrent 5.2.0+.

Resolves #2778