### PR TITLE
feat: support shareLimitAction in per-torrent view editing (qBit 5.2.0+)

### DIFF
--- a/src/components/Dialogs/ShareLimitDialog.vue
+++ b/src/components/Dialogs/ShareLimitDialog.vue
@@ -2,7 +2,7 @@
 import { computed, onBeforeMount, ref } from 'vue'
 import { useDialog, useI18nUtils } from '@/composables'
 import { ShareLimitAction } from '@/constants/qbit/AppPreferences'
-import { useMaindataStore, useTorrentStore } from '@/stores'
+import { useAppStore, useMaindataStore, useTorrentStore } from '@/stores'
 
 type ShareType = 'global' | 'disabled' | 'enabled'
 const GLOBAL = -2
@@ -17,6 +17,7 @@ const { isOpened } = useDialog(props.guid)
 const { t } = useI18nUtils()
 const maindataStore = useMaindataStore()
 const torrentStore = useTorrentStore()
+const appStore = useAppStore()
 
 const isFormValid = ref(false)
 

--- a/src/components/Dialogs/ShareLimitDialog.vue
+++ b/src/components/Dialogs/ShareLimitDialog.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { computed, onBeforeMount, ref } from 'vue'
 import { useDialog, useI18nUtils } from '@/composables'
-import { ShareLimitAction } from '@/constants/qbit/AppPreferences'
 import { useAppStore, useMaindataStore, useTorrentStore } from '@/stores'
+import { ShareLimitAction } from '@/types/vuetorrent'
 
 type ShareType = 'global' | 'disabled' | 'enabled'
 const GLOBAL = -2

--- a/src/components/Dialogs/ShareLimitDialog.vue
+++ b/src/components/Dialogs/ShareLimitDialog.vue
@@ -131,7 +131,7 @@ onBeforeMount(() => {
                 hide-details
                 :label="$t('dialogs.share_limit.inactive_seeding_time_limit')" />
             </v-col>
-            <v-col cols="12">
+            <v-col v-if="appStore.isFeatureAvailable('5.2.0')" cols="12">
               <v-select
                 v-model="shareLimitAction"
                 :items="shareLimitActions"

--- a/src/components/Dialogs/ShareLimitDialog.vue
+++ b/src/components/Dialogs/ShareLimitDialog.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onBeforeMount, ref } from 'vue'
-import { useDialog } from '@/composables'
+import { useDialog, useI18nUtils } from '@/composables'
+import { ShareLimitAction } from '@/constants/qbit/AppPreferences'
 import { useMaindataStore, useTorrentStore } from '@/stores'
 
 type ShareType = 'global' | 'disabled' | 'enabled'
@@ -13,6 +14,7 @@ const props = defineProps<{
 }>()
 
 const { isOpened } = useDialog(props.guid)
+const { t } = useI18nUtils()
 const maindataStore = useMaindataStore()
 const torrentStore = useTorrentStore()
 
@@ -29,7 +31,17 @@ const seedingTimeLimit = ref(0)
 const inactiveSeedingTimeLimitEnabled = ref(false)
 const inactiveSeedingTimeLimit = ref(0)
 
+const shareLimitAction = ref<ShareLimitAction>(ShareLimitAction.DEFAULT)
+
 const isFieldsDisabled = computed(() => shareType.value !== 'enabled')
+
+const shareLimitActions = computed(() => [
+  { title: t('common.useGlobalSettings'), value: ShareLimitAction.DEFAULT },
+  { title: t('constants.shareLimitAction.stopTorrent'), value: ShareLimitAction.STOP_TORRENT },
+  { title: t('constants.shareLimitAction.removeTorrent'), value: ShareLimitAction.REMOVE_TORRENT },
+  { title: t('constants.shareLimitAction.removeTorrentAndFiles'), value: ShareLimitAction.REMOVE_TORRENT_AND_FILES },
+  { title: t('constants.shareLimitAction.torrentSuperseeding'), value: ShareLimitAction.ENABLE_SUPERSEEDING },
+])
 
 function close() {
   isOpened.value = false
@@ -38,17 +50,18 @@ function close() {
 async function submit() {
   switch (shareType.value) {
     case 'global':
-      await maindataStore.setShareLimit(props.hashes, GLOBAL, GLOBAL, GLOBAL)
+      await maindataStore.setShareLimit(props.hashes, GLOBAL, GLOBAL, GLOBAL, ShareLimitAction.DEFAULT)
       break
     case 'disabled':
-      await maindataStore.setShareLimit(props.hashes, DISABLED, DISABLED, DISABLED)
+      await maindataStore.setShareLimit(props.hashes, DISABLED, DISABLED, DISABLED, ShareLimitAction.DEFAULT)
       break
     case 'enabled':
       await maindataStore.setShareLimit(
         props.hashes,
         ratioLimitEnabled.value ? ratioLimit.value : DISABLED,
         seedingTimeLimitEnabled.value ? seedingTimeLimit.value : DISABLED,
-        inactiveSeedingTimeLimitEnabled.value ? inactiveSeedingTimeLimit.value : DISABLED
+        inactiveSeedingTimeLimitEnabled.value ? inactiveSeedingTimeLimit.value : DISABLED,
+        shareLimitAction.value
       )
       break
   }
@@ -64,6 +77,7 @@ onBeforeMount(() => {
   const ratio_limit = torrent.ratio_limit
   const seeding_time_limit = torrent.seeding_time_limit
   const inactive_seeding_time_limit = torrent.inactive_seeding_time_limit
+  shareLimitAction.value = torrent.share_limit_action ?? ShareLimitAction.DEFAULT
 
   if (ratio_limit === GLOBAL && seeding_time_limit === GLOBAL && inactive_seeding_time_limit === GLOBAL) {
     shareType.value = 'global'
@@ -116,6 +130,17 @@ onBeforeMount(() => {
                 density="compact"
                 hide-details
                 :label="$t('dialogs.share_limit.inactive_seeding_time_limit')" />
+            </v-col>
+            <v-col cols="12">
+              <v-select
+                v-model="shareLimitAction"
+                :items="shareLimitActions"
+                item-title="title"
+                item-value="value"
+                :disabled="isFieldsDisabled"
+                density="compact"
+                hide-details
+                :label="$t('settings.bittorrent.seedLimits.then')" />
             </v-col>
           </v-row>
         </v-form>

--- a/src/components/Settings/BitTorrent.vue
+++ b/src/components/Settings/BitTorrent.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { useI18nUtils } from '@/composables'
-import { Encryption, ShareLimitAction } from '@/constants/qbit/AppPreferences'
+import { Encryption } from '@/constants/qbit/AppPreferences'
 import { useAppStore, usePreferenceStore } from '@/stores'
+import { ShareLimitAction } from '@/types/vuetorrent'
 
 const { t } = useI18nUtils()
 const appStore = useAppStore()

--- a/src/composables/TorrentBuilder.ts
+++ b/src/composables/TorrentBuilder.ts
@@ -1,14 +1,11 @@
 import { TorrentState } from '@/constants/qbit'
-import { ShareLimitAction } from '@/constants/qbit/AppPreferences'
 import { stateQbitToVt } from '@/constants/vuetorrent'
 import { basename, getDomainBody } from '@/helpers'
 import { QbitTorrent } from '@/types/qbit/models'
-import { Torrent } from '@/types/vuetorrent'
+import { ShareLimitAction, ShareLimitActionString, Torrent } from '@/types/vuetorrent'
 
 export function useTorrentBuilder() {
-  function mapShareLimitAction(
-    action: ShareLimitAction | number | 'Default' | 'Stop' | 'Remove' | 'RemoveWithContent' | 'EnableSuperSeeding' | null | undefined
-  ): ShareLimitAction {
+  function mapShareLimitAction(action: ShareLimitAction | number | ShareLimitActionString | null | undefined): ShareLimitAction {
     if (typeof action === 'number') return action
     if (action == null) return ShareLimitAction.DEFAULT
     if (typeof action === 'string') {

--- a/src/composables/TorrentBuilder.ts
+++ b/src/composables/TorrentBuilder.ts
@@ -1,10 +1,29 @@
 import { TorrentState } from '@/constants/qbit'
+import { ShareLimitAction } from '@/constants/qbit/AppPreferences'
 import { stateQbitToVt } from '@/constants/vuetorrent'
 import { basename, getDomainBody } from '@/helpers'
 import { QbitTorrent } from '@/types/qbit/models'
 import { Torrent } from '@/types/vuetorrent'
 
 export function useTorrentBuilder() {
+  function mapShareLimitAction(action: any): ShareLimitAction {
+    if (typeof action === 'number') return action
+    switch (action) {
+      case 'Default':
+        return ShareLimitAction.DEFAULT
+      case 'Stop':
+        return ShareLimitAction.STOP_TORRENT
+      case 'Remove':
+        return ShareLimitAction.REMOVE_TORRENT
+      case 'RemoveWithContent':
+        return ShareLimitAction.REMOVE_TORRENT_AND_FILES
+      case 'EnableSuperSeeding':
+        return ShareLimitAction.ENABLE_SUPERSEEDING
+      default:
+        return ShareLimitAction.DEFAULT
+    }
+  }
+
   function buildFromQbit(data: QbitTorrent): Torrent {
     return {
       added_on: data.added_on,
@@ -41,6 +60,7 @@ export function useTorrentBuilder() {
       progress: data.progress,
       ratio: Math.round(data.ratio * 100) / 100,
       ratio_limit: data.ratio_limit,
+      share_limit_action: mapShareLimitAction(data.share_limit_action),
       reannounce: data.reannounce,
       rootPath: data.root_path,
       savePath: data.save_path,

--- a/src/composables/TorrentBuilder.ts
+++ b/src/composables/TorrentBuilder.ts
@@ -6,22 +6,30 @@ import { QbitTorrent } from '@/types/qbit/models'
 import { Torrent } from '@/types/vuetorrent'
 
 export function useTorrentBuilder() {
-  function mapShareLimitAction(action: any): ShareLimitAction {
+  function mapShareLimitAction(
+    action: ShareLimitAction | number | 'Default' | 'Stop' | 'Remove' | 'RemoveWithContent' | 'EnableSuperSeeding' | null | undefined
+  ): ShareLimitAction {
     if (typeof action === 'number') return action
-    switch (action) {
-      case 'Default':
-        return ShareLimitAction.DEFAULT
-      case 'Stop':
-        return ShareLimitAction.STOP_TORRENT
-      case 'Remove':
-        return ShareLimitAction.REMOVE_TORRENT
-      case 'RemoveWithContent':
-        return ShareLimitAction.REMOVE_TORRENT_AND_FILES
-      case 'EnableSuperSeeding':
-        return ShareLimitAction.ENABLE_SUPERSEEDING
-      default:
-        return ShareLimitAction.DEFAULT
+    if (action == null) return ShareLimitAction.DEFAULT
+    if (typeof action === 'string') {
+      // map qBittorrent >= 5.2 string values to enum
+      switch (action) {
+        case 'Default':
+          return ShareLimitAction.DEFAULT
+        case 'Stop':
+          return ShareLimitAction.STOP_TORRENT
+        case 'Remove':
+          return ShareLimitAction.REMOVE_TORRENT
+        case 'RemoveWithContent':
+          return ShareLimitAction.REMOVE_TORRENT_AND_FILES
+        case 'EnableSuperSeeding':
+          return ShareLimitAction.ENABLE_SUPERSEEDING
+        default:
+          return ShareLimitAction.DEFAULT
+      }
     }
+
+    return ShareLimitAction.DEFAULT
   }
 
   function buildFromQbit(data: QbitTorrent): Torrent {

--- a/src/constants/qbit/AppPreferences.ts
+++ b/src/constants/qbit/AppPreferences.ts
@@ -33,15 +33,6 @@ export enum FileLogAgeType {
   MONTHS = 1,
   YEARS = 2,
 }
-
-export enum ShareLimitAction {
-  DEFAULT = -1,
-  STOP_TORRENT = 0,
-  REMOVE_TORRENT = 1,
-  ENABLE_SUPERSEEDING = 2,
-  REMOVE_TORRENT_AND_FILES = 3,
-}
-
 export enum ProxyType {
   NONE = 'None',
   SOCKS4 = 'SOCKS4',

--- a/src/constants/vuetorrent/Comparators.spec.ts
+++ b/src/constants/vuetorrent/Comparators.spec.ts
@@ -1,6 +1,5 @@
 import comparatorMap from './Comparators'
-import { ShareLimitAction } from '@/constants/qbit/AppPreferences'
-import { Torrent } from '@/types/vuetorrent'
+import { ShareLimitAction , Torrent } from '@/types/vuetorrent'
 
 function makeMockTorrent(overrides: Partial<Torrent> = {}): Torrent {
   return {

--- a/src/constants/vuetorrent/Comparators.spec.ts
+++ b/src/constants/vuetorrent/Comparators.spec.ts
@@ -1,4 +1,5 @@
 import comparatorMap from './Comparators'
+import { ShareLimitAction } from '@/constants/qbit/AppPreferences'
 import { Torrent } from '@/types/vuetorrent'
 
 function makeMockTorrent(overrides: Partial<Torrent> = {}): Torrent {
@@ -44,6 +45,7 @@ function makeMockTorrent(overrides: Partial<Torrent> = {}): Torrent {
     progress: 0.75,
     ratio: 1.2,
     ratio_limit: 2.0,
+    share_limit_action: ShareLimitAction.DEFAULT,
     reannounce: 30,
     rootPath: '/root',
     savePath: '/save',

--- a/src/constants/vuetorrent/Comparators.ts
+++ b/src/constants/vuetorrent/Comparators.ts
@@ -49,6 +49,7 @@ const comparatorMap: Record<keyof Torrent, (a: Torrent, b: Torrent, isAsc: boole
   progress: (a, b, isAsc) => comparators.numeric.compare(a.progress, b.progress, isAsc),
   ratio: (a, b, isAsc) => comparators.numeric.compare(a.ratio, b.ratio, isAsc),
   ratio_limit: (a, b, isAsc) => comparators.numeric.compare(a.ratio_limit, b.ratio_limit, isAsc),
+  share_limit_action: (a, b, isAsc) => comparators.numeric.compare(a.share_limit_action!, b.share_limit_action!, isAsc),
   reannounce: (a, b, isAsc) => comparators.numeric.compare(a.reannounce!, b.reannounce!, isAsc),
   rootPath: (a, b, isAsc) => comparators.text.compare(a.rootPath!, b.rootPath!, isAsc),
   savePath: (a, b, isAsc) => comparators.textWithNumbers.compare(a.savePath, b.savePath, isAsc),

--- a/src/services/qbit/IProvider.ts
+++ b/src/services/qbit/IProvider.ts
@@ -1,5 +1,6 @@
 import { AxiosResponse } from 'axios'
 import { DirectoryContentMode, FilePriority, LogType, PieceState } from '@/constants/qbit'
+import { ShareLimitAction } from '@/constants/qbit/AppPreferences'
 import {
   ApplicationVersion,
   AppPreferences,
@@ -493,8 +494,9 @@ export default interface IProvider {
    * @param ratioLimit Ratio limit
    * @param seedingTimeLimit Seeding time limit
    * @param inactiveSeedingTimeLimit Inactive seeding time limit
+   * @param shareLimitAction Share limit action
    */
-  setShareLimit(hashes: string[], ratioLimit: number, seedingTimeLimit: number, inactiveSeedingTimeLimit: number): Promise<void>
+  setShareLimit(hashes: string[], ratioLimit: number, seedingTimeLimit: number, inactiveSeedingTimeLimit: number, shareLimitAction: ShareLimitAction): Promise<void>
 
   /**
    * Reannounce torrents

--- a/src/services/qbit/IProvider.ts
+++ b/src/services/qbit/IProvider.ts
@@ -1,6 +1,5 @@
 import { AxiosResponse } from 'axios'
 import { DirectoryContentMode, FilePriority, LogType, PieceState } from '@/constants/qbit'
-import { ShareLimitAction } from '@/constants/qbit/AppPreferences'
 import {
   ApplicationVersion,
   AppPreferences,
@@ -24,6 +23,7 @@ import {
 import { NetworkInterface } from '@/types/qbit/models/AppPreferences'
 import { AddTorrentPayload, AppPreferencesPayload, CreateFeedPayload, GetTorrentPayload, LoginPayload } from '@/types/qbit/payloads'
 import { MaindataResponse, SearchResultsResponse, TorrentPeersResponse } from '@/types/qbit/responses'
+import { ShareLimitAction } from '@/types/vuetorrent'
 
 export default interface IProvider {
   /// AppController ///

--- a/src/services/qbit/MockProvider.ts
+++ b/src/services/qbit/MockProvider.ts
@@ -12,7 +12,7 @@ import {
   TorrentOperatingMode,
   TorrentState,
 } from '@/constants/qbit'
-import { ContentLayout, ProxyType, ResumeDataStorageType, StopCondition, TorrentContentRemoveOption } from '@/constants/qbit/AppPreferences'
+import { ContentLayout, ProxyType, ResumeDataStorageType, ShareLimitAction, StopCondition, TorrentContentRemoveOption } from '@/constants/qbit/AppPreferences'
 import { QBIT_MAX_ETA } from '@/constants/vuetorrent'
 import type {
   ApplicationVersion,
@@ -120,6 +120,7 @@ export default class MockProvider implements IProvider {
       progress: completed / total_size,
       ratio: 0,
       ratio_limit: -2,
+      share_limit_action: ShareLimitAction.DEFAULT,
       reannounce: 3600,
       root_path: faker.system.filePath(),
       save_path: faker.system.directoryPath(),
@@ -312,7 +313,7 @@ export default class MockProvider implements IProvider {
         max_inactive_seeding_time: -1,
         max_inactive_seeding_time_enabled: false,
         max_ratio: -1,
-        max_ratio_act: 0,
+        max_ratio_act: ShareLimitAction.STOP_TORRENT,
         max_ratio_enabled: false,
         max_seeding_time: -1,
         max_seeding_time_enabled: false,
@@ -1607,7 +1608,7 @@ export default class MockProvider implements IProvider {
     return this.generateResponse({ result: MockProvider.hashes.length })
   }
 
-  async setShareLimit(_0: string[], _1: number, _2: number, _3: number): Promise<void> {
+  async setShareLimit(_0: string[], _1: number, _2: number, _3: number, _4: ShareLimitAction): Promise<void> {
     return this.generateResponse()
   }
 

--- a/src/services/qbit/MockProvider.ts
+++ b/src/services/qbit/MockProvider.ts
@@ -12,7 +12,7 @@ import {
   TorrentOperatingMode,
   TorrentState,
 } from '@/constants/qbit'
-import { ContentLayout, ProxyType, ResumeDataStorageType, ShareLimitAction, StopCondition, TorrentContentRemoveOption } from '@/constants/qbit/AppPreferences'
+import { ContentLayout, ProxyType, ResumeDataStorageType, StopCondition, TorrentContentRemoveOption } from '@/constants/qbit/AppPreferences'
 import { QBIT_MAX_ETA } from '@/constants/vuetorrent'
 import type {
   ApplicationVersion,
@@ -39,6 +39,7 @@ import { NetworkInterface } from '@/types/qbit/models/AppPreferences'
 import type { AddTorrentPayload, GetTorrentPayload } from '@/types/qbit/payloads'
 import { AppPreferencesPayload, CreateFeedPayload, LoginPayload } from '@/types/qbit/payloads'
 import type { MaindataResponse, SearchResultsResponse, TorrentPeersResponse } from '@/types/qbit/responses'
+import { ShareLimitAction } from '@/types/vuetorrent'
 
 export default class MockProvider implements IProvider {
   private static instance: MockProvider

--- a/src/services/qbit/QbitProvider.ts
+++ b/src/services/qbit/QbitProvider.ts
@@ -3,7 +3,6 @@ import axios, { AxiosResponse } from 'axios'
 import type IProvider from './IProvider'
 import type { FilePriority } from '@/constants/qbit'
 import { DirectoryContentMode, LogType, PieceState } from '@/constants/qbit'
-import { ShareLimitAction } from '@/constants/qbit/AppPreferences'
 import type {
   ApplicationVersion,
   AppPreferences,
@@ -27,6 +26,7 @@ import type {
 import { NetworkInterface } from '@/types/qbit/models/AppPreferences'
 import type { AddTorrentPayload, AppPreferencesPayload, CreateFeedPayload, GetTorrentPayload, LoginPayload } from '@/types/qbit/payloads'
 import type { MaindataResponse, SearchResultsResponse, TorrentPeersResponse } from '@/types/qbit/responses'
+import { ShareLimitAction } from '@/types/vuetorrent'
 
 type Parameters = Record<string, any>
 

--- a/src/services/qbit/QbitProvider.ts
+++ b/src/services/qbit/QbitProvider.ts
@@ -4,7 +4,7 @@ import type IProvider from './IProvider'
 import type { FilePriority } from '@/constants/qbit'
 import { DirectoryContentMode, LogType, PieceState } from '@/constants/qbit'
 import { ShareLimitAction } from '@/constants/qbit/AppPreferences'
-import {
+import type {
   ApplicationVersion,
   AppPreferences,
   BuildInfo,

--- a/src/services/qbit/QbitProvider.ts
+++ b/src/services/qbit/QbitProvider.ts
@@ -3,7 +3,8 @@ import axios, { AxiosResponse } from 'axios'
 import type IProvider from './IProvider'
 import type { FilePriority } from '@/constants/qbit'
 import { DirectoryContentMode, LogType, PieceState } from '@/constants/qbit'
-import type {
+import { ShareLimitAction } from '@/constants/qbit/AppPreferences'
+import {
   ApplicationVersion,
   AppPreferences,
   BuildInfo,
@@ -594,12 +595,21 @@ export default class QBitProvider implements IProvider {
     return this.axios.get('/torrents/count').then(res => res.data)
   }
 
-  async setShareLimit(hashes: string[], ratioLimit: number, seedingTimeLimit: number, inactiveSeedingTimeLimit: number): Promise<void> {
+  async setShareLimit(hashes: string[], ratioLimit: number, seedingTimeLimit: number, inactiveSeedingTimeLimit: number, shareLimitAction: ShareLimitAction): Promise<void> {
+    const actionMap: Record<ShareLimitAction, string> = {
+      [ShareLimitAction.DEFAULT]: 'Default',
+      [ShareLimitAction.STOP_TORRENT]: 'Stop',
+      [ShareLimitAction.REMOVE_TORRENT]: 'Remove',
+      [ShareLimitAction.REMOVE_TORRENT_AND_FILES]: 'RemoveWithContent',
+      [ShareLimitAction.ENABLE_SUPERSEEDING]: 'EnableSuperSeeding',
+    }
+
     return this.post(`/torrents/setShareLimits`, {
       hashes: hashes.join('|'),
       ratioLimit,
       seedingTimeLimit,
       inactiveSeedingTimeLimit,
+      shareLimitAction: actionMap[shareLimitAction],
     }).then(res => res.data)
   }
 

--- a/src/stores/maindata.ts
+++ b/src/stores/maindata.ts
@@ -10,6 +10,7 @@ import { useTagStore } from './tags'
 import { useTorrentStore } from './torrents'
 import { useTrackerStore } from './trackers'
 import { useVueTorrentStore } from './vuetorrent'
+import { ShareLimitAction } from '@/constants/qbit/AppPreferences'
 import qbit from '@/services/qbit'
 import { ServerState } from '@/types/qbit/models'
 import { isFullUpdate } from '@/types/qbit/responses'
@@ -109,8 +110,8 @@ export const useMaindataStore = defineStore('maindata', () => {
     return await qbit.setUploadLimit(hashes, limit)
   }
 
-  async function setShareLimit(hashes: string[], ratioLimit: number, seedingTimeLimit: number, inactiveSeedingTimeLimit: number) {
-    return await qbit.setShareLimit(hashes, ratioLimit, seedingTimeLimit, inactiveSeedingTimeLimit)
+  async function setShareLimit(hashes: string[], ratioLimit: number, seedingTimeLimit: number, inactiveSeedingTimeLimit: number, shareLimitAction: ShareLimitAction) {
+    return await qbit.setShareLimit(hashes, ratioLimit, seedingTimeLimit, inactiveSeedingTimeLimit, shareLimitAction)
   }
 
   return {

--- a/src/stores/maindata.ts
+++ b/src/stores/maindata.ts
@@ -10,10 +10,10 @@ import { useTagStore } from './tags'
 import { useTorrentStore } from './torrents'
 import { useTrackerStore } from './trackers'
 import { useVueTorrentStore } from './vuetorrent'
-import { ShareLimitAction } from '@/constants/qbit/AppPreferences'
 import qbit from '@/services/qbit'
 import { ServerState } from '@/types/qbit/models'
 import { isFullUpdate } from '@/types/qbit/responses'
+import { ShareLimitAction } from '@/types/vuetorrent'
 
 export const useMaindataStore = defineStore('maindata', () => {
   const rid = ref<number>()

--- a/src/types/qbit/models/AppPreferences.ts
+++ b/src/types/qbit/models/AppPreferences.ts
@@ -8,13 +8,13 @@ import type {
   ProxyType,
   ScanDirs,
   SchedulerDays,
-  ShareLimitAction,
   StopCondition,
   UploadChokingAlgorithm,
   UploadSlotsBehavior,
   UtpTcpMixedMode,
 } from '@/constants/qbit/AppPreferences'
 import { AutoDeleteMode, FileLogAgeType, ResumeDataStorageType, TorrentContentRemoveOption } from '@/constants/qbit/AppPreferences'
+import type { ShareLimitAction } from '@/types/vuetorrent'
 
 export interface NetworkInterface {
   name: string

--- a/src/types/qbit/models/Torrent.ts
+++ b/src/types/qbit/models/Torrent.ts
@@ -1,5 +1,5 @@
 import type { TorrentState } from '@/constants/qbit'
-import { ShareLimitAction } from '@/constants/qbit/AppPreferences'
+import { ShareLimitAction } from '@/types/vuetorrent'
 
 export interface RawTorrent {
   /** Time (Unix Epoch) when the torrent was added to the client */

--- a/src/types/qbit/models/Torrent.ts
+++ b/src/types/qbit/models/Torrent.ts
@@ -1,4 +1,5 @@
 import type { TorrentState } from '@/constants/qbit'
+import { ShareLimitAction } from '@/constants/qbit/AppPreferences'
 
 export interface RawTorrent {
   /** Time (Unix Epoch) when the torrent was added to the client */
@@ -85,6 +86,11 @@ export interface RawTorrent {
   ratio: number
   /** Upload share ratio limit */
   ratio_limit: number
+  /**
+   * Action to perform when share limit is reached
+   * @since 5.2.0
+   */
+  share_limit_action?: ShareLimitAction
   /**
    * Seconds until next tracker reannounce
    * @since 5.0.0

--- a/src/types/qbit/payloads/AddTorrentPayload.ts
+++ b/src/types/qbit/payloads/AddTorrentPayload.ts
@@ -1,4 +1,5 @@
-import { ContentLayout, ShareLimitAction, StopCondition } from '@/constants/qbit/AppPreferences'
+import { ContentLayout, StopCondition } from '@/constants/qbit/AppPreferences'
+import { ShareLimitAction } from '@/types/vuetorrent'
 
 export default interface AddTorrentPayload {
   /** Whether to add the torrent at the top of the queue */

--- a/src/types/vuetorrent/ShareLimitAction.ts
+++ b/src/types/vuetorrent/ShareLimitAction.ts
@@ -1,0 +1,11 @@
+export enum ShareLimitAction {
+  DEFAULT = -1,
+  STOP_TORRENT = 0,
+  REMOVE_TORRENT = 1,
+  ENABLE_SUPERSEEDING = 2,
+  REMOVE_TORRENT_AND_FILES = 3,
+}
+
+export type ShareLimitActionString = 'Default' | 'Stop' | 'Remove' | 'RemoveWithContent' | 'EnableSuperSeeding'
+
+export { ShareLimitAction as default }

--- a/src/types/vuetorrent/Torrent.ts
+++ b/src/types/vuetorrent/Torrent.ts
@@ -1,4 +1,4 @@
-import { ShareLimitAction } from "."
+import { ShareLimitAction } from './ShareLimitAction'
 import { TorrentState } from '@/constants/vuetorrent/TorrentState'
 
 export default interface Torrent {

--- a/src/types/vuetorrent/Torrent.ts
+++ b/src/types/vuetorrent/Torrent.ts
@@ -1,4 +1,4 @@
-import { ShareLimitAction } from '@/constants/qbit/AppPreferences'
+import { ShareLimitAction } from "."
 import { TorrentState } from '@/constants/vuetorrent/TorrentState'
 
 export default interface Torrent {

--- a/src/types/vuetorrent/Torrent.ts
+++ b/src/types/vuetorrent/Torrent.ts
@@ -1,3 +1,4 @@
+import { ShareLimitAction } from '@/constants/qbit/AppPreferences'
 import { TorrentState } from '@/constants/vuetorrent/TorrentState'
 
 export default interface Torrent {
@@ -45,6 +46,8 @@ export default interface Torrent {
   progress: number
   ratio: number
   ratio_limit: number
+  /** @since 5.2.0 */
+  share_limit_action?: ShareLimitAction
   /** @since 5.0.0 */
   reannounce?: number
   /** @since 5.1.0 */

--- a/src/types/vuetorrent/index.ts
+++ b/src/types/vuetorrent/index.ts
@@ -4,9 +4,11 @@ import type RightClickProperties from './RightClickProperties'
 import type { RssArticle } from './RssArticle'
 import type { SearchData } from './SearchData'
 import type SearchResult from './SearchResult'
+import { ShareLimitAction } from './ShareLimitAction'
+import type { ShareLimitActionString } from './ShareLimitAction'
 import type SidebarWidget from './SidebarWidget'
 import type Torrent from './Torrent'
 import { TreeFile, TreeFolder } from './TreeObjects'
 import type { TreeNode } from './TreeObjects'
 
-export { Cookie, RssArticle, SearchData, Torrent, TreeNode, TreeFile, TreeFolder, RightClickMenuEntryType, RightClickProperties, SearchResult, SidebarWidget }
+export { Cookie, RssArticle, SearchData, Torrent, TreeNode, TreeFile, TreeFolder, RightClickMenuEntryType, RightClickProperties, SearchResult, SidebarWidget, ShareLimitAction, ShareLimitActionString }


### PR DESCRIPTION
# fix: support shareLimitAction for qBittorrent 5.2.0 compatibility [fix]

This PR addresses issue #2778 where editing the per-torrent share limit returns an HTTP 400 error on qBittorrent 5.2.0. The new API version requires `shareLimitAction` to be sent as a string (e.g., 'Stop', 'Remove') instead of an integer.

### Changes:
- Updated `setShareLimits` API call to map numeric enum values to the string literals expected by qBittorrent 5.2.0.
- Implemented a reverse mapping in `TorrentBuilder` to convert these string actions back to numeric values, ensuring correct localization and display in the UI.
- Added the "Then" selection field to the `ShareLimitDialog` to allow users to choose the action to perform when limits are reached.
- Maintained numeric compatibility for global preferences in the main settings to avoid display bugs.
- Updated unit tests for comparators and fixed linting issues.

Closes #2778.

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code