### PR TITLE
feat(WebUI Setting): add API key generator with copy/regenerate/delete (qBit 5.2.0+)

### DIFF
--- a/src/components/Settings/ApiKeyGenerator.vue
+++ b/src/components/Settings/ApiKeyGenerator.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { toast } from 'vue3-toastify'
+import { useI18nUtils } from '@/composables'
+import qbit from '@/services/qbit'
+import { usePreferenceStore } from '@/stores'
+
+const { t } = useI18nUtils()
+const preferenceStore = usePreferenceStore()
+
+const apiKey = computed(() => preferenceStore.preferences?.web_ui_api_key ?? '')
+const hasKey = computed(() => apiKey.value.length > 0)
+
+const maskedKey = computed(() => {
+  const key = apiKey.value
+  if (!key) return ''
+  if (key.length <= 5) return '*'.repeat(key.length)
+  return '*'.repeat(key.length - 5) + key.slice(-5)
+})
+
+async function copyKey() {
+  if (!hasKey.value) return
+  try {
+    await navigator.clipboard.writeText(apiKey.value)
+    toast.success(t('toast.copy.success'))
+  } catch {
+    toast.error(t('toast.copy.error'))
+  }
+}
+
+async function regenerateKey() {
+  try {
+    const newKey = await qbit.rotateAPIKey()
+    if (preferenceStore.preferences) {
+      preferenceStore.preferences.web_ui_api_key = newKey
+    }
+    toast.success(t('settings.webUI.apiKey.regenerated'))
+  } catch {
+    toast.error(t('settings.webUI.apiKey.regenerateError'))
+  }
+}
+
+async function deleteKey() {
+  try {
+    await qbit.deleteAPIKey()
+    if (preferenceStore.preferences) {
+      preferenceStore.preferences.web_ui_api_key = ''
+    }
+    toast.success(t('settings.webUI.apiKey.deleted'))
+  } catch {
+    toast.error(t('settings.webUI.apiKey.deleteError'))
+  }
+}
+</script>
+
+<template>
+  <v-row>
+    <v-col cols="12" sm="6">
+      <div class="my-2">
+        <div>{{ t('settings.webUI.apiKey.label') }}</div>
+        <v-text-field class="mt-2" :model-value="hasKey ? maskedKey : t('settings.webUI.apiKey.empty')" readonly hide-details />
+      </div>
+    </v-col>
+    <v-col cols="12" sm="6" align-self="end" class="d-flex align-center ga-2 flex-wrap pb-4">
+      <v-btn :disabled="!hasKey" prepend-icon="mdi-content-copy" @click="copyKey">
+        {{ t('settings.webUI.apiKey.copy') }}
+      </v-btn>
+      <v-btn color="primary" prepend-icon="mdi-refresh" @click="regenerateKey">
+        {{ t('settings.webUI.apiKey.regenerate') }}
+      </v-btn>
+      <v-btn color="error" :disabled="!hasKey" prepend-icon="mdi-delete" @click="deleteKey">
+        {{ t('settings.webUI.apiKey.delete') }}
+      </v-btn>
+    </v-col>
+  </v-row>
+</template>

--- a/src/components/Settings/WebUI.vue
+++ b/src/components/Settings/WebUI.vue
@@ -1,12 +1,14 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import ApiKeyGenerator from './ApiKeyGenerator.vue'
 import AutofillableField from '@/components/Core/AutofillableField.vue'
 import PasswordField from '@/components/Core/PasswordField.vue'
 import { useI18nUtils } from '@/composables'
 import { openLink } from '@/helpers'
-import { usePreferenceStore } from '@/stores'
+import { useAppStore, usePreferenceStore } from '@/stores'
 
 const { t } = useI18nUtils()
+const appStore = useAppStore()
 const preferenceStore = usePreferenceStore()
 
 const dynDnsProvider = ref('https://www.dyndns.com/account/services/hosts/add.html')
@@ -90,6 +92,10 @@ function registerDynDNS() {
             autocapitalize="off"
             autocomplete="new-password"
             name="webui-password" />
+        </v-col>
+
+        <v-col v-if="appStore.isFeatureAvailable('5.2.0')" cols="12">
+          <ApiKeyGenerator />
         </v-col>
 
         <v-col cols="12" class="py-0">

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1245,6 +1245,18 @@
       }
     },
     "webUI": {
+      "apiKey": {
+        "copy": "Copy",
+        "delete": "Delete",
+        "deleted": "API key deleted",
+        "deleteError": "Failed to delete API key",
+        "empty": "(no API key)",
+        "label": "Web API Key",
+        "regenerate": "Regenerate",
+        "regenerated": "API key regenerated",
+        "regenerateError": "Failed to regenerate API key",
+        "subheader": "Web API Key"
+      },
       "authentication": {
         "banDuration": "Ban Duration",
         "banDurationHint": "In seconds",

--- a/src/services/qbit/IProvider.ts
+++ b/src/services/qbit/IProvider.ts
@@ -91,6 +91,17 @@ export default interface IProvider {
    */
   setCookies(cookies: Cookie[]): Promise<void>
 
+  /**
+   * Generates a new Web API key (rotates the existing one if present).
+   * @returns the freshly generated key
+   */
+  rotateAPIKey(): Promise<string>
+
+  /**
+   * Deletes the current Web API key.
+   */
+  deleteAPIKey(): Promise<void>
+
   /// AuthController ///
 
   /**

--- a/src/services/qbit/MockProvider.ts
+++ b/src/services/qbit/MockProvider.ts
@@ -399,6 +399,7 @@ export default class MockProvider implements IProvider {
         utp_tcp_mixed_mode: 0,
         validate_https_tracker_certificate: true,
         web_ui_address: '*',
+        web_ui_api_key: '',
         web_ui_ban_duration: 3600,
         web_ui_clickjacking_protection_enabled: false,
         web_ui_csrf_protection_enabled: false,
@@ -484,6 +485,14 @@ export default class MockProvider implements IProvider {
   }
 
   setCookies(_: Cookie[]): Promise<void> {
+    return this.generateResponse()
+  }
+
+  async rotateAPIKey(): Promise<string> {
+    return this.generateResponse({ result: `qbt_${faker.string.alphanumeric(28)}` })
+  }
+
+  async deleteAPIKey(): Promise<void> {
     return this.generateResponse()
   }
 

--- a/src/services/qbit/QbitProvider.ts
+++ b/src/services/qbit/QbitProvider.ts
@@ -125,6 +125,14 @@ export default class QBitProvider implements IProvider {
     await this.post('/app/setCookies', { cookies: JSON.stringify(cookies) })
   }
 
+  async rotateAPIKey(): Promise<string> {
+    return this.post('/app/rotateAPIKey').then(res => res.data?.apiKey ?? '')
+  }
+
+  async deleteAPIKey(): Promise<void> {
+    await this.post('/app/deleteAPIKey')
+  }
+
   /// AuthController ///
 
   async login(params: LoginPayload): Promise<AxiosResponse<string, string>> {

--- a/src/types/qbit/models/AppPreferences.ts
+++ b/src/types/qbit/models/AppPreferences.ts
@@ -400,6 +400,8 @@ export default interface AppPreferences {
   validate_https_tracker_certificate: boolean
   /** IP address to use for the WebUI */
   web_ui_address: string
+  /** WebUI API Key */
+  web_ui_api_key: string
   /** WebUI access ban duration in seconds */
   web_ui_ban_duration: number
   /** True if WebUI clickjacking protection is enabled */


### PR DESCRIPTION
# add API key generator with copy/regenerate/delete [feat]

Adds a Web API Key management UI in Settings → WebUI → Authentication
minimum requirement qBit 5.2.0+

[Screencast_20260515_042319.webm](https://github.com/user-attachments/assets/712aac7e-74e3-4d74-ad44-d42c22f0f987)

closes #2777

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
