### PR TITLE
fix(5.2): Update editTracker endpoint payload

### DIFF
--- a/src/services/qbit/QbitProvider.ts
+++ b/src/services/qbit/QbitProvider.ts
@@ -655,6 +655,7 @@ export default class QBitProvider implements IProvider {
   async editTorrentTracker(hash: string, origUrl: string, newUrl: string): Promise<void> {
     const params = {
       hash,
+      url: origUrl,
       origUrl,
       newUrl,
     }


### PR DESCRIPTION
Update Qbit 5.2 payload to support parameter rename