### PR TITLE
fix: speedCard text wraping to new line in using bits units

### DIFF
--- a/src/components/Navbar/SideWidgets/Cards/BaseCard.vue
+++ b/src/components/Navbar/SideWidgets/Cards/BaseCard.vue
@@ -35,12 +35,14 @@ const contentOrientation = computed(() => {
         <template v-if="Array.isArray(value)">
           <template v-for="(val, i) in value" :key="i">
             <v-divider v-if="i > 0" opacity=".75" thickness="2" style="border-top-style: dashed" />
-            <div>
+            <div class="text-no-wrap">
               <slot :value="val"></slot>
             </div>
           </template>
         </template>
-        <slot v-else :value="value"></slot>
+        <span v-else class="text-no-wrap">
+          <slot :value="value"></slot>
+        </span>
       </div>
     </div>
   </v-sheet>


### PR DESCRIPTION
# fix speedCard text wraping to new line in using bits units [fix]

BaseCard has wrap-anywhere (CSS overflow-wrap: anywhere) on the content div, which combined with a narrow card width allowed the unit span to break to a new line. 

this PR fixes that with wraping the BaseCard in text-no-wrap.

before:
<img width="251" height="294" alt="image" src="https://github.com/user-attachments/assets/fbe06b40-aa1a-4a14-afdc-9c3952136169" />

after:
<img width="265" height="279" alt="image" src="https://github.com/user-attachments/assets/e185cde0-e427-4051-a101-f4187eb7c43b" />


closes #2811 


## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
