### PR TITLE
Add ability to log in using an API key

### DIFF
--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -41,7 +41,9 @@ function redirectOnSuccess() {
 }
 
 onMounted(async () => {
-  if (route.query.username && route.query.password) {
+  if (route.query.apiKey) {
+    await appStore.loginWithApiKey(route.query.apiKey as string)
+  } else if (route.query.username && route.query.password) {
     await appStore.login(route.query.username as string, route.query.password as string)
   }
 })

--- a/src/services/qbit/IProvider.ts
+++ b/src/services/qbit/IProvider.ts
@@ -118,7 +118,7 @@ export default interface IProvider {
   /**
    * Test the provided API key by making a request to the version endpoint.
    */
-  testApiKey(key: string): Promise<ApplicationVersion>
+  testApiKey(key: string): Promise<ApplicationVersion | undefined>
 
   /**
    * Logout from the application

--- a/src/services/qbit/IProvider.ts
+++ b/src/services/qbit/IProvider.ts
@@ -103,12 +103,22 @@ export default interface IProvider {
    */
   deleteAPIKey(): Promise<void>
 
+  /**
+   * Set the API key to use for all subsequent requests (qBittorrent 5.2.0+).
+   */
+  setApiKey(key: string | null): void
+
   /// AuthController ///
 
   /**
    * Login to the application
    */
   login(params: LoginPayload): Promise<AxiosResponse<string, string>>
+
+  /**
+   * Test the provided API key by making a request to the version endpoint.
+   */
+  testApiKey(key: string): Promise<ApplicationVersion>
 
   /**
    * Logout from the application

--- a/src/services/qbit/MockProvider.ts
+++ b/src/services/qbit/MockProvider.ts
@@ -498,6 +498,8 @@ export default class MockProvider implements IProvider {
     return this.generateResponse()
   }
 
+  setApiKey(_key: string | null): void {}
+
   /// AuthController ///
 
   async login(_: LoginPayload): Promise<AxiosResponse<string, string>> {
@@ -508,6 +510,10 @@ export default class MockProvider implements IProvider {
         statusText: 'OK',
       } as AxiosResponse<string, string>,
     })
+  }
+
+  async testApiKey(_: string): Promise<ApplicationVersion> {
+    return this.generateResponse({ result: '5.2.2', delay: 50 })
   }
 
   async logout(): Promise<void> {

--- a/src/services/qbit/MockProvider.ts
+++ b/src/services/qbit/MockProvider.ts
@@ -512,7 +512,7 @@ export default class MockProvider implements IProvider {
     })
   }
 
-  async testApiKey(_: string): Promise<ApplicationVersion> {
+  async testApiKey(_: string): Promise<ApplicationVersion | undefined> {
     return this.generateResponse({ result: '5.2.2', delay: 50 })
   }
 

--- a/src/services/qbit/QbitProvider.ts
+++ b/src/services/qbit/QbitProvider.ts
@@ -1,5 +1,5 @@
 import type { AxiosInstance, AxiosRequestConfig } from 'axios'
-import axios, { AxiosResponse } from 'axios'
+import axios, { isAxiosError, AxiosResponse } from 'axios'
 import type IProvider from './IProvider'
 import type { FilePriority } from '@/constants/qbit'
 import { DirectoryContentMode, LogType, PieceState } from '@/constants/qbit'
@@ -95,7 +95,9 @@ export default class QBitProvider implements IProvider {
       .then(res => res.data)
       .then(version => (version.includes('v') ? version.substring(1) : version))
       .catch(e => {
-        this.setApiKey(null)
+        if (isAxiosError(e) && e.response?.status === 403) {
+          this.setApiKey(null)
+        }
         throw e
       })
   }
@@ -161,7 +163,7 @@ export default class QBitProvider implements IProvider {
     return this.post('/auth/login', params, { validateStatus: () => true })
   }
 
-  async testApiKey(key: string): Promise<ApplicationVersion> {
+  async testApiKey(key: string): Promise<ApplicationVersion | undefined> {
     return this.axios
       .get('/app/version', { headers: { Authorization: `Bearer ${key}` }, validateStatus: () => true })
       .then(res => (res.status >= 200 && res.status < 300 ? res.data : undefined))

--- a/src/services/qbit/QbitProvider.ts
+++ b/src/services/qbit/QbitProvider.ts
@@ -94,6 +94,10 @@ export default class QBitProvider implements IProvider {
       .get('/app/version')
       .then(res => res.data)
       .then(version => (version.includes('v') ? version.substring(1) : version))
+      .catch(e => {
+        this.setApiKey(null)
+        throw e
+      })
   }
 
   async getPreferences(): Promise<AppPreferences> {

--- a/src/services/qbit/QbitProvider.ts
+++ b/src/services/qbit/QbitProvider.ts
@@ -30,6 +30,8 @@ import { ShareLimitAction } from '@/types/vuetorrent'
 
 type Parameters = Record<string, any>
 
+const API_KEY_STORAGE_KEY = 'vuetorrent_apiKey'
+
 export default class QBitProvider implements IProvider {
   private static _instance: QBitProvider
   private axios: AxiosInstance
@@ -40,6 +42,11 @@ export default class QBitProvider implements IProvider {
     })
 
     this.axios.defaults.headers.post['Content-Type'] = 'application/x-www-form-urlencoded'
+
+    const apiKey = sessionStorage.getItem(API_KEY_STORAGE_KEY)
+    if (apiKey) {
+      this.setApiKey(apiKey)
+    }
   }
 
   public static getInstance() {
@@ -47,6 +54,16 @@ export default class QBitProvider implements IProvider {
       this._instance = new QBitProvider()
     }
     return this._instance
+  }
+
+  setApiKey(key: string | null): void {
+    if (key === null) {
+      delete this.axios.defaults.headers.common['Authorization']
+      sessionStorage.removeItem(API_KEY_STORAGE_KEY)
+    } else {
+      this.axios.defaults.headers.common['Authorization'] = `Bearer ${key}`
+      sessionStorage.setItem(API_KEY_STORAGE_KEY, key)
+    }
   }
 
   /// Misc ///
@@ -140,7 +157,15 @@ export default class QBitProvider implements IProvider {
     return this.post('/auth/login', params, { validateStatus: () => true })
   }
 
+  async testApiKey(key: string): Promise<ApplicationVersion> {
+    return this.axios
+      .get('/app/version', { headers: { Authorization: `Bearer ${key}` }, validateStatus: () => true })
+      .then(res => (res.status >= 200 && res.status < 300 ? res.data : undefined))
+      .then(version => (version?.includes('v') ? version.substring(1) : version))
+  }
+
   async logout(): Promise<void> {
+    this.setApiKey(null)
     await this.post('/auth/logout')
   }
 

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -42,6 +42,15 @@ export const useAppStore = defineStore('app', () => {
     return response
   }
 
+  async function loginWithApiKey(key: string) {
+    const result = await qbit.testApiKey(key)
+    if (result) {
+      qbit.setApiKey(key)
+      await setAuthStatus(true, result)
+    }
+    return result
+  }
+
   async function logout() {
     await qbit.logout()
     await setAuthStatus(false)
@@ -72,6 +81,7 @@ export const useAppStore = defineStore('app', () => {
     shutdownQbit,
     sendTestEmail,
     login,
+    loginWithApiKey,
     logout,
     toggleAlternativeMode,
     $reset: async () => {

--- a/src/stores/maindata.ts
+++ b/src/stores/maindata.ts
@@ -76,6 +76,7 @@ export const useMaindataStore = defineStore('maindata', () => {
     } catch (error: any) {
       if (error?.response?.status === 403) {
         console.error('No longer authenticated, logging out...')
+        qbit.setApiKey(null)
         await appStore.setAuthStatus(false)
         await vueTorrentStore.redirectToLogin()
       } else {


### PR DESCRIPTION
# Add ability to log in using an API key [feat]

Adds the ability to log in by passing an apiKey query param at the login page (like the existing username & pw logic)
The idea is to use it like this: `http://localhost:3000/#/login?apiKey=blahblah`

[Screencast_20260624_232316.webm](https://github.com/user-attachments/assets/7f667d90-3c90-40bf-b999-9049f412a540)

In case the apiKey is valid the received version is passed to `setAuthStatus` so there's no need to do an additional api request. The api key is stored in sessionStorage (now that I think about it, I could probably change it to localStorage) so refreshing the page reuses the key. The key is reset on logout or when a 403 is detected.

Tried using claude to speed things up but it pretty much did the opposite.

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
