### PR TITLE
Add useFilenameAsRename option for adding torrents [feat]

### DIFF
--- a/src/components/Dialogs/AddTorrentDialog.vue
+++ b/src/components/Dialogs/AddTorrentDialog.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { storeToRefs } from 'pinia'
-import { computed, onBeforeMount, ref } from 'vue'
+import { computed, onBeforeMount, ref, watch } from 'vue'
 import { toast } from 'vue3-toastify'
 import AddTorrentParamsForm from './AddTorrentParamsForm.vue'
 import HistoryField from '@/components/Core/HistoryField.vue'
@@ -44,6 +44,16 @@ const rename = computed({
   set: value => (form.value.rename = value || undefined),
 })
 
+watch(
+  () => [files.value, form.value.useFilenameAsRename],
+  () => {
+    if (form.value.useFilenameAsRename && files.value.length === 1) {
+      form.value.rename = files.value[0].name.replace(/\.torrent$/i, '')
+    }
+  },
+  { deep: true }
+)
+
 function submit() {
   if (!isFormValid.value) return
 
@@ -73,9 +83,23 @@ function submit() {
   }
 
   const torrentsCount = files.value.length + urls.value.split('\n').filter(url => url.trim().length).length
+  
+  const promises = []
+  if (form.value.useFilenameAsRename && files.value.length > 1) {
+    for (const file of files.value) {
+      const filePayload = { ...payload, rename: file.name.replace(/\.torrent$/i, '') }
+      promises.push(torrentStore.addTorrents([file], '', filePayload))
+    }
+    if (urls.value) {
+      promises.push(torrentStore.addTorrents([], urls.value, payload))
+    }
+  } else {
+    promises.push(torrentStore.addTorrents(files.value, urls.value, payload))
+  }
+
   void toast
     .promise(
-      torrentStore.addTorrents(files.value, urls.value, payload),
+      Promise.all(promises),
       {
         pending: t('toast.add.pending'),
         error: t('toast.add.error', torrentsCount),
@@ -172,6 +196,14 @@ onBeforeMount(() => {
                 <v-icon color="accent"> mdi-rename </v-icon>
               </template>
             </v-text-field>
+
+            <v-tooltip :text="$t('dialogs.add.use_filename_warning')" location="bottom" :disabled="files.length <= 1">
+              <template #activator="{ props: tooltipProps }">
+                <div v-bind="tooltipProps">
+                  <v-checkbox v-model="form.useFilenameAsRename" :label="$t('dialogs.add.use_filename')" color="accent" density="compact" hide-details />
+                </div>
+              </template>
+            </v-tooltip>
           </v-col>
         </v-row>
 

--- a/src/components/Dialogs/AddTorrentDialog.vue
+++ b/src/components/Dialogs/AddTorrentDialog.vue
@@ -44,11 +44,15 @@ const rename = computed({
   set: value => (form.value.rename = value || undefined),
 })
 
+function stripTorrentExtension(filename: string): string {
+  return filename.replace(/\.torrent$/i, '')
+}
+
 watch(
   () => [files.value, form.value.useFilenameAsRename],
   () => {
     if (form.value.useFilenameAsRename && files.value.length === 1) {
-      form.value.rename = files.value[0].name.replace(/\.torrent$/i, '')
+      form.value.rename = stripTorrentExtension(files.value[0].name)
     }
   },
   { deep: true }
@@ -83,26 +87,68 @@ function submit() {
   }
 
   const torrentsCount = files.value.length + urls.value.split('\n').filter(url => url.trim().length).length
-  
-  const promises = []
+
+  const promises: Promise<void>[] = []
+
   if (form.value.useFilenameAsRename && files.value.length > 1) {
     for (const file of files.value) {
-      const filePayload = { ...payload, rename: file.name.replace(/\.torrent$/i, '') }
-      promises.push(torrentStore.addTorrents([file], '', filePayload))
+      const filePayload = { ...payload, rename: stripTorrentExtension(file.name) }
+      const p = torrentStore
+        .addTorrents([file], '', filePayload)
+        .then(() => {
+          files.value = files.value.filter(f => f.name !== file.name)
+        })
+        .catch(err => {
+          const e = new Error(err.message || String(err))
+          ;(e as any).fileName = file.name
+          return Promise.reject(e)
+        })
+      promises.push(p)
     }
     if (urls.value) {
-      promises.push(torrentStore.addTorrents([], urls.value, payload))
+      const p = torrentStore
+        .addTorrents([], urls.value, payload)
+        .then(() => {
+          urls.value = ''
+        })
+        .catch(err => {
+          const e = new Error(err.message || String(err))
+          ;(e as any).fileName = 'URLs'
+          return Promise.reject(e)
+        })
+      promises.push(p)
     }
   } else {
-    promises.push(torrentStore.addTorrents(files.value, urls.value, payload))
+    promises.push(
+      torrentStore.addTorrents(files.value, urls.value, payload).then(() => {
+        files.value = []
+        urls.value = ''
+      })
+    )
   }
+
+  const batchPromise = Promise.allSettled(promises).then(results => {
+    const failed = results.filter(r => r.status === 'rejected')
+    if (failed.length > 0) {
+      if (form.value.useFilenameAsRename && files.value.length > 1) {
+        const failedNames = failed.map(r => r.reason?.fileName || 'unknown').join(', ')
+        throw new Error(`${failed.length}/${results.length} torrent(s) failed to add. Failed torrents: ${failedNames}`)
+      } else {
+        throw failed[0].reason instanceof Error ? failed[0].reason : new Error(String(failed[0].reason))
+      }
+    }
+  })
 
   void toast
     .promise(
-      Promise.all(promises),
+      batchPromise,
       {
         pending: t('toast.add.pending'),
-        error: t('toast.add.error', torrentsCount),
+        error: {
+          render({ data }: { data: Error }) {
+            return data.message || t('toast.add.error', torrentsCount)
+          },
+        },
         success: t('toast.add.success', torrentsCount),
       },
       {
@@ -112,8 +158,10 @@ function submit() {
     .then(() => {
       cookieField.value?.saveValueToHistory()
       addTorrentParamsForm.value?.saveFields()
-      addTorrentStore.resetForm()
-      close()
+      if (files.value.length === 0 && urls.value === '') {
+        addTorrentStore.resetForm()
+        close()
+      }
     })
 }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -315,7 +315,9 @@
       "reset_form": "Reset form",
       "sequential_download": "Sequential download",
       "submit": "Add torrents",
-      "title": "Add Torrents"
+      "title": "Add Torrents",
+      "use_filename": "Use filename as torrent name",
+      "use_filename_warning": "Warning: Adding multiple torrents at once with this option enabled may cause instability if you upload a very large number of files simultaneously."
     },
     "bulkEditTrackers": {
       "add": "Trackers to add",

--- a/src/stores/addTorrents.ts
+++ b/src/stores/addTorrents.ts
@@ -19,6 +19,7 @@ export const useAddTorrentStore = defineStore(
         firstLastPiecePrio: boolean
         rename: string
         sequentialDownload: boolean
+        useFilenameAsRename: boolean
       }>
     >({})
     const addTorrentParams = reactive<AddTorrentParams>({})
@@ -52,6 +53,7 @@ export const useAddTorrentStore = defineStore(
       form.firstLastPiecePrio = false
       form.rename = undefined
       form.sequentialDownload = false
+      form.useFilenameAsRename = false
 
       addTorrentParams.add_to_top_of_queue = preferenceStore.preferences!.add_to_top_of_queue
       addTorrentParams.category = undefined


### PR DESCRIPTION
This PR introduces a new toggle in the Add Torrent dialog to automatically use the uploaded torrent's filename as the initial value for the rename field.

When adding a torrent file, checking the "Use Filename" option will strip the `.torrent` extension and populate the "Rename" input, saving the user from manually typing out the name.

**Motivation:**
This is especially useful when handling large batches of torrents (e.g., `1.torrent`, `2.torrent`) that the user has already pre-organized by renaming the `.torrent` files directly prior to uploading them to the UI.

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code