### PR TITLE
feat(search): Configurable default sort order for search results

### DIFF
--- a/src/components/Settings/VueTorrent/SearchEngine.vue
+++ b/src/components/Settings/VueTorrent/SearchEngine.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18nUtils } from '@/composables'
+import { SearchEngineColumn } from '@/constants/vuetorrent'
+import { useAppStore, useVueTorrentStore } from '@/stores'
+
+const { t } = useI18nUtils()
+const appStore = useAppStore()
+const vueTorrentStore = useVueTorrentStore()
+
+const sortColumnOptions = computed(() => [
+  { title: t('settings.vuetorrent.searchEngine.sortNone'), value: SearchEngineColumn.NONE },
+  { title: t('searchEngine.headers.fileName'), value: SearchEngineColumn.FILE_NAME },
+  { title: t('searchEngine.headers.fileSize'), value: SearchEngineColumn.FILE_SIZE },
+  { title: t('searchEngine.headers.nbSeeders'), value: SearchEngineColumn.NB_SEEDERS },
+  { title: t('searchEngine.headers.nbLeechers'), value: SearchEngineColumn.NB_LEECHERS },
+  ...(appStore.usesQbit5
+    ? [
+        { title: t('searchEngine.headers.engineName'), value: SearchEngineColumn.ENGINE_NAME },
+        { title: t('searchEngine.headers.pubDate'), value: SearchEngineColumn.PUB_DATE },
+      ]
+    : [{ title: t('searchEngine.headers.siteUrl'), value: SearchEngineColumn.SITE_URL }]),
+])
+
+const sortOrderOptions = computed(() => [
+  { title: t('settings.vuetorrent.searchEngine.sortAsc'), value: 'asc' },
+  { title: t('settings.vuetorrent.searchEngine.sortDesc'), value: 'desc' },
+])
+</script>
+
+<template>
+  <v-list>
+    <v-list-item>
+      <v-row>
+        <v-col cols="12" md="6">
+          <v-select
+            v-model="vueTorrentStore.searchEngineDefaultSortBy"
+            flat
+            hide-details
+            :items="sortColumnOptions"
+            :label="t('settings.vuetorrent.searchEngine.defaultSortBy')" />
+        </v-col>
+        <v-col cols="12" md="6">
+          <v-select
+            v-model="vueTorrentStore.searchEngineDefaultSortOrder"
+            flat
+            hide-details
+            :disabled="vueTorrentStore.searchEngineDefaultSortBy === SearchEngineColumn.NONE"
+            :items="sortOrderOptions"
+            :label="t('settings.vuetorrent.searchEngine.defaultSortOrder')" />
+        </v-col>
+      </v-row>
+    </v-list-item>
+  </v-list>
+</template>

--- a/src/constants/vuetorrent/SearchEngineColumn.ts
+++ b/src/constants/vuetorrent/SearchEngineColumn.ts
@@ -1,0 +1,10 @@
+export enum SearchEngineColumn {
+  NONE = 'none',
+  FILE_NAME = 'fileName',
+  FILE_SIZE = 'fileSize',
+  NB_SEEDERS = 'nbSeeders',
+  NB_LEECHERS = 'nbLeechers',
+  ENGINE_NAME = 'engineName',
+  PUB_DATE = 'pubDate',
+  SITE_URL = 'siteUrl'
+}

--- a/src/constants/vuetorrent/index.ts
+++ b/src/constants/vuetorrent/index.ts
@@ -9,6 +9,7 @@ import { extMap, FileType, typesMap } from './FileIcon'
 import { FilterState } from './FilterState'
 import { FilterType } from './FilterType'
 import { HistoryKey } from './HistoryKey'
+import { SearchEngineColumn } from './SearchEngineColumn'
 import { ThemeMode } from './ThemeMode'
 import { TitleOptions } from './TitleOptions'
 import { TorrentDetailTab } from './TorrentDetailTab'
@@ -33,6 +34,7 @@ export {
   FilterState,
   FilterType,
   HistoryKey,
+  SearchEngineColumn,
   ThemeMode,
   TitleOptions,
   TorrentDetailTab,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1150,6 +1150,7 @@
       "tagsAndCategories": "Tags & Categories",
       "vuetorrent": {
         "general": "General",
+        "searchEngine": "Search Engine",
         "sidebar": "Sidebar",
         "title": "VueTorrent",
         "torrent_card": {
@@ -1213,6 +1214,13 @@
         "useBitSpeed": "Replace speed values by bits (kB/s -> kbps)",
         "useEmojiState": "Prepend torrent states with emojis",
         "vueTorrentTitle": "Tab title"
+      },
+      "searchEngine": {
+        "defaultSortBy": "Default sort column",
+        "defaultSortOrder": "Default sort direction",
+        "sortAsc": "Ascending",
+        "sortDesc": "Descending",
+        "sortNone": "None"
       },
       "sidebar": {
         "ConnectionStats": "Show Connection Stats",

--- a/src/pages/SearchEngine.vue
+++ b/src/pages/SearchEngine.vue
@@ -239,6 +239,7 @@ onBeforeUnmount(() => {
         <v-data-table
           v-if="mobile"
           v-model:items-per-page="selectedTab.itemsPerPage"
+          v-model:sort-by="selectedTab.sortBy"
           :mobile="true"
           :headers="headers"
           :items="filteredResults"
@@ -325,6 +326,7 @@ onBeforeUnmount(() => {
         <v-data-table
           v-else
           v-model:items-per-page="selectedTab.itemsPerPage"
+          v-model:sort-by="selectedTab.sortBy"
           :mobile="false"
           :headers="headers"
           :items="filteredResults"

--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -13,6 +13,7 @@ import RSS from '@/components/Settings/RSS.vue'
 import Speed from '@/components/Settings/Speed.vue'
 import TagsAndCategories from '@/components/Settings/TagsAndCategories.vue'
 import VGeneral from '@/components/Settings/VueTorrent/General.vue'
+import VSearchEngine from '@/components/Settings/VueTorrent/SearchEngine.vue'
 import VSidebar from '@/components/Settings/VueTorrent/Sidebar.vue'
 import VTorrentCardGrid from '@/components/Settings/VueTorrent/TorrentCard/Grid.vue'
 import VTorrentCardList from '@/components/Settings/VueTorrent/TorrentCard/List.vue'
@@ -46,6 +47,7 @@ const tabsV = [
   { text: t('settings.tabs.vuetorrent.torrent_card.grid'), value: 'torrentCardGrid' },
   { text: t('settings.tabs.vuetorrent.torrent_card.table'), value: 'torrentCardTable' },
   { text: t('settings.tabs.vuetorrent.sidebar'), value: 'sidebar' },
+  { text: t('settings.tabs.vuetorrent.searchEngine'), value: 'searchEngine' },
 ]
 
 const tab = ref('vuetorrent')
@@ -159,6 +161,9 @@ onBeforeUnmount(() => {
           </v-window-item>
           <v-window-item value="sidebar" :transition="keepDefaultTransitions" :reverse-transition="keepDefaultTransitions">
             <VSidebar />
+          </v-window-item>
+          <v-window-item value="searchEngine" :transition="keepDefaultTransitions" :reverse-transition="keepDefaultTransitions">
+            <VSearchEngine />
           </v-window-item>
         </v-window>
       </v-window-item>

--- a/src/stores/searchEngine.ts
+++ b/src/stores/searchEngine.ts
@@ -1,6 +1,8 @@
 import { acceptHMRUpdate, defineStore } from 'pinia'
 import { v4 as uuidv4 } from 'uuid'
 import { ref } from 'vue'
+import { useVueTorrentStore } from './vuetorrent'
+import { SearchEngineColumn } from '@/constants/vuetorrent'
 import qbit from '@/services/qbit'
 import { SearchPlugin } from '@/types/qbit/models'
 import { SearchData } from '@/types/vuetorrent'
@@ -12,6 +14,7 @@ export const useSearchEngineStore = defineStore(
     const searchPlugins = ref<SearchPlugin[]>([])
 
     function createNewTab() {
+      const vueTorrentStore = useVueTorrentStore()
       searchData.value.push({
         uniqueId: uuidv4(),
         id: 0,
@@ -25,6 +28,10 @@ export const useSearchEngineStore = defineStore(
         },
         results: [],
         timer: null,
+        sortBy:
+          vueTorrentStore.searchEngineDefaultSortBy === SearchEngineColumn.NONE
+            ? []
+            : [{ key: vueTorrentStore.searchEngineDefaultSortBy, order: vueTorrentStore.searchEngineDefaultSortOrder }],
       })
     }
 

--- a/src/stores/vuetorrent.ts
+++ b/src/stores/vuetorrent.ts
@@ -11,6 +11,7 @@ import {
   PropertyData,
   propsData,
   propsMetadata,
+  SearchEngineColumn,
   ThemeMode,
   TitleOptions,
   TorrentDetailTab,
@@ -52,6 +53,8 @@ export const useVueTorrentStore = defineStore(
     const reduceMotion = ref(false)
     const keepDefaultTransitions = computed(() => !reduceMotion.value)
     const defaultTorrentDetailTab = ref(TorrentDetailTab.LAST_OPENED)
+    const searchEngineDefaultSortBy = ref(SearchEngineColumn.NONE)
+    const searchEngineDefaultSortOrder = ref<'asc' | 'desc'>('desc')
     const tableColumnWidths = ref<Record<string, Record<string, number>>>({})
     const logoutUrl = ref('')
 
@@ -303,6 +306,8 @@ export const useVueTorrentStore = defineStore(
       reduceMotion,
       keepDefaultTransitions,
       defaultTorrentDetailTab,
+      searchEngineDefaultSortBy,
+      searchEngineDefaultSortOrder,
       logoutUrl,
       $reset: () => {
         language.value = 'en'
@@ -332,6 +337,8 @@ export const useVueTorrentStore = defineStore(
         expandContent.value = true
         reduceMotion.value = false
         defaultTorrentDetailTab.value = TorrentDetailTab.LAST_OPENED
+        searchEngineDefaultSortBy.value = SearchEngineColumn.NONE
+        searchEngineDefaultSortOrder.value = 'desc'
         tableColumnWidths.value = {}
         logoutUrl.value = ''
 

--- a/src/types/vuetorrent/SearchData.ts
+++ b/src/types/vuetorrent/SearchData.ts
@@ -15,4 +15,5 @@ export interface SearchData {
   itemsPerPage: number
   filters: SearchFilters
   results: SearchResult[]
+  sortBy?: { key: string; order: 'asc' | 'desc' }[]
 }


### PR DESCRIPTION
Closes #2859

## Summary
- Adds a **Search Engine** subtab under Settings → VueTorrent to configure a default sort column/order for search-result tables, since qBittorrent's API has no server-side preference for this.
- New search tabs are seeded with the configured default sort; changing the sort on an individual tab (via the table header) only affects that tab, not the saved default.
- Adds a `SearchEngineColumn` enum shared between the settings UI and the search-result table sort state, filtered by `appStore.usesQbit5` to match the column logic already used on the Search Engine page.

## Test plan
- [x] `npm run lint`
- [x] `npm run test` (376 passed)
- [X] Manually verify in the browser: set a default sort in Settings → VueTorrent → Search Engine, open a new search tab, confirm it's pre-sorted; change sort on the tab and confirm the saved default is unaffected.

## Screenshots
<img width="1000" alt="Screenshot 2026-07-16 at 09 30 45" src="https://github.com/user-attachments/assets/15da0805-54b4-4a67-8f97-9b9c30a7721c" />

<img width="1000" alt="Screenshot 2026-07-16 at 09 30 57" src="https://github.com/user-attachments/assets/41b19e14-1c7d-424f-92d7-5fbfc8116a17" />
