### PR TITLE
feat: show raw data values on hover

### DIFF
--- a/src/components/Core/RawNumber.vue
+++ b/src/components/Core/RawNumber.vue
@@ -18,7 +18,7 @@ const formattedValue = computed(() => {
 <template>
   <v-tooltip :text="formattedValue" location="top">
     <template #activator="{ props: activatorProps }">
-      <span v-bind="activatorProps" class="raw-number">
+      <span v-bind="activatorProps" class="raw-number" tabindex="0">
         <slot />
       </span>
     </template>
@@ -31,5 +31,10 @@ const formattedValue = computed(() => {
   text-decoration-line: underline;
   text-decoration-style: dotted;
   text-underline-offset: 0.2em;
+}
+
+.raw-number:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
 }
 </style>

--- a/src/components/Core/RawNumber.vue
+++ b/src/components/Core/RawNumber.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { formatRawNumber } from '@/helpers'
+
+const props = defineProps<{ value: number }>()
+const { locale } = useI18n()
+
+const formattedValue = computed(() => {
+  const parts = new Intl.NumberFormat(locale.value).formatToParts(1000.1)
+  const thousandsSeparator = parts.find(part => part.type === 'group')?.value ?? ','
+  const decimalSeparator = parts.find(part => part.type === 'decimal')?.value ?? '.'
+
+  return formatRawNumber(props.value, thousandsSeparator, decimalSeparator)
+})
+</script>
+
+<template>
+  <v-tooltip :text="formattedValue" location="top">
+    <template #activator="{ props: activatorProps }">
+      <span v-bind="activatorProps" class="raw-number">
+        <slot />
+      </span>
+    </template>
+  </v-tooltip>
+</template>
+
+<style scoped>
+.raw-number {
+  cursor: help;
+  text-decoration-line: underline;
+  text-decoration-style: dotted;
+  text-underline-offset: 0.2em;
+}
+</style>

--- a/src/components/Core/RawNumberTooltip.vue
+++ b/src/components/Core/RawNumberTooltip.vue
@@ -18,7 +18,7 @@ const formattedValue = computed(() => {
 <template>
   <v-tooltip :text="formattedValue" location="top">
     <template #activator="{ props: activatorProps }">
-      <span v-bind="activatorProps" class="raw-number" tabindex="0">
+      <span v-bind="activatorProps" class="raw-number-tooltip" tabindex="0">
         <slot />
       </span>
     </template>
@@ -26,14 +26,14 @@ const formattedValue = computed(() => {
 </template>
 
 <style scoped>
-.raw-number {
+.raw-number-tooltip {
   cursor: help;
   text-decoration-line: underline;
   text-decoration-style: dotted;
   text-underline-offset: 0.2em;
 }
 
-.raw-number:focus-visible {
+.raw-number-tooltip:focus-visible {
   outline: 2px solid currentColor;
   outline-offset: 2px;
 }

--- a/src/components/Dashboard/DashboardItems/ItemData.vue
+++ b/src/components/Dashboard/DashboardItems/ItemData.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
 import { computed } from 'vue'
+import RawNumber from '@/components/Core/RawNumber.vue'
 import { formatDataUnit, formatDataValue } from '@/helpers'
 import { useVueTorrentStore } from '@/stores'
 import { Torrent } from '@/types/vuetorrent'
@@ -17,10 +18,12 @@ const val = computed(() => props.value(props.torrent))
       {{ $t(titleKey) }}
     </div>
     <div>
-      {{ formatDataValue(val, useBinarySize) }}
-      <span class="text-caption text-grey">
-        {{ formatDataUnit(val, useBinarySize) }}
-      </span>
+      <RawNumber :value="val">
+        {{ formatDataValue(val, useBinarySize) }}
+        <span class="text-caption text-grey">
+          {{ formatDataUnit(val, useBinarySize) }}
+        </span>
+      </RawNumber>
     </div>
   </div>
 </template>

--- a/src/components/Dashboard/DashboardItems/ItemData.vue
+++ b/src/components/Dashboard/DashboardItems/ItemData.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
 import { computed } from 'vue'
-import RawNumber from '@/components/Core/RawNumber.vue'
+import RawNumberTooltip from '@/components/Core/RawNumberTooltip.vue'
 import { formatDataUnit, formatDataValue } from '@/helpers'
 import { useVueTorrentStore } from '@/stores'
 import { Torrent } from '@/types/vuetorrent'
@@ -18,12 +18,12 @@ const val = computed(() => props.value(props.torrent))
       {{ $t(titleKey) }}
     </div>
     <div>
-      <RawNumber :value="val">
+      <RawNumberTooltip :value="val">
         {{ formatDataValue(val, useBinarySize) }}
         <span class="text-caption text-grey">
           {{ formatDataUnit(val, useBinarySize) }}
         </span>
-      </RawNumber>
+      </RawNumberTooltip>
     </div>
   </div>
 </template>

--- a/src/components/Dashboard/Views/Table/DashboardItems/ItemData.vue
+++ b/src/components/Dashboard/Views/Table/DashboardItems/ItemData.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
+import RawNumber from '@/components/Core/RawNumber.vue'
 import { formatData } from '@/helpers'
 import { useVueTorrentStore } from '@/stores'
 import { Torrent } from '@/types/vuetorrent'
@@ -11,6 +12,8 @@ const { useBinarySize } = storeToRefs(useVueTorrentStore())
 
 <template>
   <td class="text-no-wrap">
-    {{ formatData(value(torrent), useBinarySize) }}
+    <RawNumber :value="value(torrent)">
+      {{ formatData(value(torrent), useBinarySize) }}
+    </RawNumber>
   </td>
 </template>

--- a/src/components/Dashboard/Views/Table/DashboardItems/ItemData.vue
+++ b/src/components/Dashboard/Views/Table/DashboardItems/ItemData.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
-import RawNumber from '@/components/Core/RawNumber.vue'
+import RawNumberTooltip from '@/components/Core/RawNumberTooltip.vue'
 import { formatData } from '@/helpers'
 import { useVueTorrentStore } from '@/stores'
 import { Torrent } from '@/types/vuetorrent'
@@ -12,8 +12,8 @@ const { useBinarySize } = storeToRefs(useVueTorrentStore())
 
 <template>
   <td class="text-no-wrap">
-    <RawNumber :value="value(torrent)">
+    <RawNumberTooltip :value="value(torrent)">
       {{ formatData(value(torrent), useBinarySize) }}
-    </RawNumber>
+    </RawNumberTooltip>
   </td>
 </template>

--- a/src/components/TorrentDetail/Content/ContentNode.vue
+++ b/src/components/TorrentDetail/Content/ContentNode.vue
@@ -3,6 +3,7 @@ import { vOnLongPress } from '@vueuse/components'
 import { storeToRefs } from 'pinia'
 import { computed, triggerRef } from 'vue'
 import { useDisplay } from 'vuetify'
+import RawNumberTooltip from '@/components/Core/RawNumberTooltip.vue'
 import { useI18nUtils } from '@/composables'
 import { FilePriority } from '@/constants/qbit'
 import { doesCommand, formatData, formatPercent, getFileIcon } from '@/helpers'
@@ -69,24 +70,6 @@ function getNodeDeepCount(node: TreeNode) {
 
   return res.join(', ')
 }
-
-function getNodeSubtitle(node: TreeNode) {
-  const size = formatData(node.size, vuetorrentStore.useBinarySize)
-  const selectedSize = formatData(node.selectedSize, vuetorrentStore.useBinarySize)
-
-  let values: string[]
-  if (node.type === 'folder') {
-    let displayedSize = size
-    if (node.selectedSize > 0) {
-      displayedSize += ` (${selectedSize})`
-    }
-    values = [displayedSize, getNodeDeepCount(node)]
-  } else {
-    values = [size]
-  }
-
-  return values.join(' | ')
-}
 </script>
 
 <template>
@@ -128,7 +111,19 @@ function getNodeSubtitle(node: TreeNode) {
           {{ node.name }}
         </div>
         <div class="text-grey">
-          {{ getNodeSubtitle(node) }}
+          <RawNumberTooltip :value="node.size">
+            {{ formatData(node.size, vuetorrentStore.useBinarySize) }}
+          </RawNumberTooltip>
+          <template v-if="node.type === 'folder' && node.selectedSize > 0">
+            (
+            <RawNumberTooltip :value="node.selectedSize">
+              {{ formatData(node.selectedSize, vuetorrentStore.useBinarySize) }}
+            </RawNumberTooltip>
+            )
+          </template>
+          <template v-if="node.type === 'folder'">
+            {{ ` | ${getNodeDeepCount(node)}` }}
+          </template>
         </div>
       </div>
 

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -3,7 +3,7 @@ import comparators, { Comparator, isObjectEqual } from './comparators'
 import { formatData, formatDataUnit, formatDataValue } from './data'
 import { formatDuration, formatEta, formatTimeMs, formatTimeSec } from './datetime'
 import { arrayRemove } from './misc'
-import { formatPercent, toPrecision, safeDiv } from './number'
+import { formatPercent, formatRawNumber, toPrecision, safeDiv } from './number'
 import { basename, getExtType, getFileIcon, getTypeIcon, splitExt } from './path'
 import { formatSpeed, formatSpeedUnit, formatSpeedValue } from './speed'
 import { doesCommand, downloadFile, isMac, isWindows, openLink } from './system'
@@ -26,6 +26,7 @@ export {
   arrayRemove,
   toPrecision,
   formatPercent,
+  formatRawNumber,
   safeDiv,
   basename,
   splitExt,

--- a/src/helpers/number.spec.ts
+++ b/src/helpers/number.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { formatPercent, toPrecision, safeDiv } from './number'
+import { formatPercent, formatRawNumber, toPrecision, safeDiv } from './number'
 
 describe('helpers/number', () => {
   test('toPrecision', () => {
@@ -23,6 +23,17 @@ describe('helpers/number', () => {
     expect(formatPercent(1)).toBe('100 %')
 
     expect(formatPercent(0.999942870757758)).toBe('99.9 %')
+  })
+
+  test.each([
+    [1234567.89, ',', '.', '1,234,567.89'],
+    [1234567.89, ' ', '.', '1 234 567.89'],
+    [1234567.89, ' ', ',', '1 234 567,89'],
+    [1234567, ',', '.', '1,234,567'],
+    [0, ',', '.', '0'],
+    [-1234567.89, ',', '.', '-1,234,567.89'],
+  ])('formatRawNumber(%s, %s, %s)', (value, thousandsSeparator, decimalSeparator, expected) => {
+    expect(formatRawNumber(value, thousandsSeparator, decimalSeparator)).toBe(expected)
   })
 
   test('safeDiv', () => {

--- a/src/helpers/number.spec.ts
+++ b/src/helpers/number.spec.ts
@@ -32,6 +32,8 @@ describe('helpers/number', () => {
     [1234567, ',', '.', '1,234,567'],
     [0, ',', '.', '0'],
     [-1234567.89, ',', '.', '-1,234,567.89'],
+    [1e21, ',', '.', '1,000,000,000,000,000,000,000'],
+    [1e-7, ',', '.', '0.0000001'],
   ])('formatRawNumber(%s, %s, %s)', (value, thousandsSeparator, decimalSeparator, expected) => {
     expect(formatRawNumber(value, thousandsSeparator, decimalSeparator)).toBe(expected)
   })

--- a/src/helpers/number.ts
+++ b/src/helpers/number.ts
@@ -15,6 +15,14 @@ export function toPrecision(value: number, precision: number): string {
   }
 }
 
+/** Formats a raw number using the provided thousands and decimal separators. */
+export function formatRawNumber(value: number, thousandsSeparator: string, decimalSeparator: string): string {
+  const [integerPart, decimalPart] = value.toString().split('.')
+  const formattedInteger = integerPart.replace(/\B(?=(\d{3})+(?!\d))/g, thousandsSeparator)
+
+  return decimalPart ? `${formattedInteger}${decimalSeparator}${decimalPart}` : formattedInteger
+}
+
 /** Formats a percentage value between 0 and 1 */
 export function formatPercent(progress: number): string {
   return `${toPrecision(progress * 100, 3)} %`

--- a/src/helpers/number.ts
+++ b/src/helpers/number.ts
@@ -15,9 +15,23 @@ export function toPrecision(value: number, precision: number): string {
   }
 }
 
+function expandScientificNotation(value: string): string {
+  const match = value.match(/^(-?)(\d+)(?:\.(\d+))?e([+-]?\d+)$/i)
+  if (!match) return value
+
+  const [, sign, integerPart, fractionPart = '', exponentText] = match
+  const digits = integerPart + fractionPart
+  const decimalIndex = integerPart.length + Number(exponentText)
+
+  if (decimalIndex <= 0) return `${sign}0.${'0'.repeat(-decimalIndex)}${digits}`
+  if (decimalIndex >= digits.length) return `${sign}${digits}${'0'.repeat(decimalIndex - digits.length)}`
+
+  return `${sign}${digits.slice(0, decimalIndex)}.${digits.slice(decimalIndex)}`
+}
+
 /** Formats a raw number using the provided thousands and decimal separators. */
 export function formatRawNumber(value: number, thousandsSeparator: string, decimalSeparator: string): string {
-  const [integerPart, decimalPart] = value.toString().split('.')
+  const [integerPart, decimalPart] = expandScientificNotation(value.toString()).split('.')
   const formattedInteger = integerPart.replace(/\B(?=(\d{3})+(?!\d))/g, thousandsSeparator)
 
   return decimalPart ? `${formattedInteger}${decimalSeparator}${decimalPart}` : formattedInteger


### PR DESCRIPTION
# Raw data values on hover [feat]

## Summary

- show locale-aware raw numeric values in a tooltip while keeping compact values in the UI
- add a reusable `RawNumber` component for dashboard cards and torrent table cells
- add and export `formatRawNumber` with unit tests
- keep tooltip content tied to each rendered value to avoid stale or mismatched hover text

Fixes #2427

## Testing

- `npm run lint`
- `npm test` (25 files, 382 tests)
- `npm run build`

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code