### PR TITLE
Use tabs to switch between RSS Feeds and Rules [feat]

### DIFF
--- a/src/pages/RssArticles.vue
+++ b/src/pages/RssArticles.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import DOMPurify from 'dompurify'
-import { computed, nextTick, onMounted, onUnmounted, reactive, ref } from 'vue'
+import { computed, nextTick, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useDisplay } from 'vuetify'
 import Feeds from '@/components/RSS/Feeds/Feeds.vue'
@@ -20,7 +20,8 @@ const rssDescription = reactive({
   content: '',
 })
 
-const feedsView = computed(() => route.params.tab !== 'rules')
+const currentTab = computed(() => (route.params.tab === 'rules' ? 'rules' : 'feeds'))
+const feedsView = computed(() => currentTab.value === 'feeds')
 const height = computed(() => {
   // 64px for the toolbar
   // 12px for the padding (top and bottom)
@@ -48,10 +49,7 @@ function openRssArticle(article: RssArticle) {
   })
 }
 
-function toggleFeedsView() {
-  const tab = route.params.tab === 'rules' ? 'feeds' : 'rules'
-  void router.replace({ name: 'rssArticles', params: { tab } }).then(() => (rssStore.lastView = tab))
-}
+watch(currentTab, tab => (rssStore.lastView = tab), { immediate: true })
 
 function goHome() {
   void router.push({ name: 'dashboard' })
@@ -80,18 +78,11 @@ onUnmounted(() => {
 <template>
   <div class="pa-3">
     <div class="d-flex align-center">
-      <div class="text-headline-medium ml-2">
-        {{ feedsView ? $t('rssArticles.feeds.title') : $t('rssArticles.rules.title') }}
-      </div>
-      <v-spacer />
-      <div class="d-flex justify-end">
-        <v-tooltip :text="$t(feedsView ? 'rssArticles.toggle.rules' : 'rssArticles.toggle.feeds')" location="top">
-          <template #activator="{ props }">
-            <v-btn icon="mdi-auto-download" v-bind="props" variant="plain" @click="toggleFeedsView()" />
-          </template>
-        </v-tooltip>
-        <v-btn icon="mdi-close" variant="plain" @click="goHome()" />
-      </div>
+      <v-tabs :model-value="currentTab" color="accent" grow show-arrows>
+        <v-tab value="feeds" :text="$t('rssArticles.feeds.title')" prepend-icon="mdi-rss" replace :to="{ name: 'rssArticles', params: { tab: 'feeds' } }" />
+        <v-tab value="rules" :text="$t('rssArticles.rules.title')" prepend-icon="mdi-auto-download" replace :to="{ name: 'rssArticles', params: { tab: 'rules' } }" />
+      </v-tabs>
+      <v-btn icon="mdi-close" variant="plain" @click="goHome()" />
     </div>
 
     <Feeds v-if="feedsView" :height="height" :mobile="mobile" @open-article="openRssArticle" />


### PR DESCRIPTION
Closes #2874

The RSS page switched between Feeds and Rules with a plain `mdi-auto-download` icon button in
the header. The glyph is a letter "A" with a down arrow, nearly identical to
`mdi-sort-alphabetical-descending`, `variant="plain"` stripped the button affordance, and it sat
beside `mdi-close` so it read as a sort or window control. The only label was a tooltip, which
never appears on touch. Net effect: the Rules view was hard to find, as in #1722.

This replaces it with `<v-tabs>`, matching the pattern the Settings page already uses
(`src/pages/Settings.vue:126-134`).

The state was already tab-shaped, so the change is small:

- the route is already `/rss/:tab?/:feedId?` (`src/pages/index.ts:16`)
- `feedsView` was already derived from `route.params.tab` (`RssArticles.vue:23`)

So the tabs bind straight to it with `:to` + `replace`, and `toggleFeedsView()` is no longer
needed. A watcher keeps `rssStore.lastView` in sync, so reopening RSS from the topbar still
restores whichever tab was used last.

No new i18n keys: the existing `rssArticles.feeds.title` and `rssArticles.rules.title` become the
tab labels. No locale files touched, per the contributing guide. `rssArticles.toggle.*` is now
unused, left in place for Tolgee to retire.

<img width="875" height="260" alt="t" src="https://github.com/user-attachments/assets/bdc10dd4-1e6d-4e9e-90ec-f9567ae667d7" />

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
