### PR TITLE
feat: Add ability to define "favorite" download paths

### DIFF
--- a/src/components/Core/ServerPathField.vue
+++ b/src/components/Core/ServerPathField.vue
@@ -9,6 +9,7 @@ import { useAppStore, useHistoryStore } from '@/stores'
 const props = defineProps<{
   title: string
   historyKey: HistoryKey
+  extraItems?: string[]
 }>()
 
 const modelValue = defineModel<string | undefined>({ required: true })
@@ -21,15 +22,14 @@ const comboboxRef = ref<HTMLInputElement>()
 const historyItems = computed(() => historyStore.getHistory(props.historyKey))
 
 const allItems = computed(() => {
-  const history = historyItems.value
-  const server = serverItems.value
+  const combined: string[] = []
+  const seen = new Set<string>()
 
-  const combined = [...history]
-  server.forEach(item => {
-    if (!combined.includes(item)) {
-      combined.push(item)
-    }
-  })
+  for (const item of [...(props.extraItems ?? []), ...historyItems.value, ...serverItems.value]) {
+    if (!item || seen.has(item)) continue
+    seen.add(item)
+    combined.push(item)
+  }
 
   return combined
 })

--- a/src/components/Dialogs/AddTorrentParamsForm.vue
+++ b/src/components/Dialogs/AddTorrentParamsForm.vue
@@ -4,7 +4,7 @@ import ServerPathField from '@/components/Core/ServerPathField.vue'
 import { useI18nUtils } from '@/composables'
 import { AppPreferences } from '@/constants/qbit'
 import { HistoryKey } from '@/constants/vuetorrent'
-import { useAppStore, useCategoryStore, usePreferenceStore, useTagStore } from '@/stores'
+import { useAppStore, useCategoryStore, usePreferenceStore, useTagStore, useVueTorrentStore } from '@/stores'
 import { AddTorrentParams } from '@/types/qbit/models'
 
 const form = defineModel<AddTorrentParams>({ required: true })
@@ -14,6 +14,7 @@ const appStore = useAppStore()
 const categoryStore = useCategoryStore()
 const preferenceStore = usePreferenceStore()
 const tagStore = useTagStore()
+const vueTorrentStore = useVueTorrentStore()
 
 const contentLayoutOptions = [
   { title: t('common.useGlobalSettings'), value: null },
@@ -187,6 +188,7 @@ defineExpose({ saveFields })
       <ServerPathField
         ref="savePathField"
         v-model="form.save_path"
+        :extra-items="vueTorrentStore.favoriteSavePaths"
         :history-key="HistoryKey.TORRENT_PATH"
         :disabled="form.use_auto_tmm"
         :title="t('dialogs.add.params.save_path')"

--- a/src/components/Settings/Downloads.vue
+++ b/src/components/Settings/Downloads.vue
@@ -259,14 +259,7 @@ async function sendTestEmail() {
         </v-col>
 
         <v-col cols="12">
-          <v-combobox
-            v-model="favoriteSavePaths"
-            chips
-            clearable
-            closable-chips
-            hide-details
-            multiple
-            :label="t('settings.downloads.saveManagement.favoriteSavePaths')" />
+          <v-combobox v-model="favoriteSavePaths" chips clearable closable-chips hide-details multiple :label="t('settings.downloads.saveManagement.favoriteSavePaths')" />
         </v-col>
 
         <v-col cols="12">

--- a/src/components/Settings/Downloads.vue
+++ b/src/components/Settings/Downloads.vue
@@ -4,13 +4,14 @@ import { toast } from 'vue3-toastify'
 import { useI18nUtils } from '@/composables'
 import { AppPreferences } from '@/constants/qbit'
 import { ScanDirs, ScanDirsEnum } from '@/constants/qbit/AppPreferences'
-import { useAppStore, usePreferenceStore } from '@/stores'
+import { useAppStore, usePreferenceStore, useVueTorrentStore } from '@/stores'
 
 type MonitoredFolder = { monitoredFolderPath: string; saveType: ScanDirs | -1; otherPath: string }
 
 const { t } = useI18nUtils()
 const appStore = useAppStore()
 const preferenceStore = usePreferenceStore()
+const vueTorrentStore = useVueTorrentStore()
 
 const autoDeleteModeOptions = [
   { title: t('constants.auto_delete_mode.never'), value: AppPreferences.AutoDeleteMode.NEVER },
@@ -76,6 +77,11 @@ const addStoppedEnabled = computed({
     preferenceStore.preferences.add_stopped_enabled = v
     preferenceStore.preferences.start_paused_enabled = v
   },
+})
+
+const favoriteSavePaths = computed({
+  get: () => vueTorrentStore.favoriteSavePaths,
+  set: value => vueTorrentStore.setFavoriteSavePaths(value),
 })
 
 onBeforeMount(() => {
@@ -250,6 +256,17 @@ async function sendTestEmail() {
 
         <v-col cols="12">
           <v-text-field v-model="preferenceStore.preferences!.save_path" hide-details :label="t('settings.downloads.saveManagement.defaultSavePath')" />
+        </v-col>
+
+        <v-col cols="12">
+          <v-combobox
+            v-model="favoriteSavePaths"
+            chips
+            clearable
+            closable-chips
+            hide-details
+            multiple
+            :label="t('settings.downloads.saveManagement.favoriteSavePaths')" />
         </v-col>
 
         <v-col cols="12">

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1074,6 +1074,7 @@
         },
         "exportDir": "Copy .torrent files to",
         "exportDirFinished": "Copy .torrent files for finished downloads to",
+        "favoriteSavePaths": "Favorite Save Paths",
         "keepIncomplete": "Default Download Path (incomplete torrents)",
         "paramChangedTMMOptions": {
           "relocateTorrent": "Relocate torrent",

--- a/src/stores/vuetorrent.spec.ts
+++ b/src/stores/vuetorrent.spec.ts
@@ -1,0 +1,50 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+import { useVueTorrentStore } from './vuetorrent'
+
+vi.mock('@vueuse/core', () => ({
+  useMediaQuery: () => ref(false),
+}))
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({
+    currentRoute: ref({ path: '/' }),
+    push: vi.fn(),
+  }),
+}))
+
+vi.mock('vuetify', () => ({
+  useTheme: () => ({
+    change: vi.fn(),
+  }),
+}))
+
+vi.mock('@/composables', () => ({
+  useI18nUtils: () => ({
+    locale: ref('en'),
+  }),
+}))
+
+describe('useVueTorrentStore favorite save paths', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('normalizes favorite save paths', () => {
+    const store = useVueTorrentStore()
+
+    store.setFavoriteSavePaths([' /downloads/movies ', '', '/downloads/tv', '/downloads/movies', '   '])
+
+    expect(store.favoriteSavePaths).toEqual(['/downloads/movies', '/downloads/tv'])
+  })
+
+  it('clears favorite save paths on reset', () => {
+    const store = useVueTorrentStore()
+    store.setFavoriteSavePaths(['/downloads'])
+
+    store.$reset()
+
+    expect(store.favoriteSavePaths).toEqual([])
+  })
+})

--- a/src/stores/vuetorrent.ts
+++ b/src/stores/vuetorrent.ts
@@ -21,6 +21,17 @@ import { DarkLegacy, LightLegacy } from '@/themes'
 export const useVueTorrentStore = defineStore(
   'vuetorrent',
   () => {
+    function normalizeFavoriteSavePaths(paths: string[]) {
+      const seen = new Set<string>()
+      return paths.reduce<string[]>((acc, path) => {
+        const normalizedPath = path.trim()
+        if (!normalizedPath || seen.has(normalizedPath)) return acc
+        seen.add(normalizedPath)
+        acc.push(normalizedPath)
+        return acc
+      }, [])
+    }
+
     const language = ref('en')
     const theme = reactive({
       mode: ThemeMode.SYSTEM,
@@ -53,6 +64,7 @@ export const useVueTorrentStore = defineStore(
     const keepDefaultTransitions = computed(() => !reduceMotion.value)
     const defaultTorrentDetailTab = ref(TorrentDetailTab.LAST_OPENED)
     const tableColumnWidths = ref<Record<string, Record<string, number>>>({})
+    const favoriteSavePaths = ref<string[]>([])
     const logoutUrl = ref('')
 
     const _busyProperties = ref<PropertyData>(JSON.parse(JSON.stringify(propsData)))
@@ -248,6 +260,10 @@ export const useVueTorrentStore = defineStore(
       _tableProperties.value[name].active = !_tableProperties.value[name].active
     }
 
+    function setFavoriteSavePaths(paths: string[]) {
+      favoriteSavePaths.value = normalizeFavoriteSavePaths(paths)
+    }
+
     return {
       theme,
       dateFormat,
@@ -304,6 +320,8 @@ export const useVueTorrentStore = defineStore(
       keepDefaultTransitions,
       defaultTorrentDetailTab,
       logoutUrl,
+      favoriteSavePaths,
+      setFavoriteSavePaths,
       $reset: () => {
         language.value = 'en'
         theme.mode = ThemeMode.SYSTEM
@@ -334,6 +352,7 @@ export const useVueTorrentStore = defineStore(
         defaultTorrentDetailTab.value = TorrentDetailTab.LAST_OPENED
         tableColumnWidths.value = {}
         logoutUrl.value = ''
+        favoriteSavePaths.value = []
 
         _busyProperties.value = JSON.parse(JSON.stringify(propsData))
         _doneProperties.value = JSON.parse(JSON.stringify(propsData))


### PR DESCRIPTION
# Feat: add ability to define "favorite" download paths

When downloading things, I often have to write in the specific directory from the default save path that I want to put the files in. This PR allows me to define "favorite" download paths that will always appear in the dropdown menu. Small QoL fix that I find useful.
Defining favorite paths:
<img width="2557" height="1225" alt="favorite1" src="https://github.com/user-attachments/assets/771dbda4-e50e-4cee-8b69-3d1a27e20a03" />

Paths show in dropdown:

https://github.com/user-attachments/assets/559bdc6c-d9d6-4956-aa37-0a7207e266e4



## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code
