### PR TITLE
fix(Settings): API key copy not working in insecure contexts

### DIFF
--- a/src/components/Dashboard/RightClick.vue
+++ b/src/components/Dashboard/RightClick.vue
@@ -2,9 +2,8 @@
 import { BlobReader, BlobWriter, ZipWriter } from '@zip.js/zip.js'
 import { computed, defineAsyncComponent } from 'vue'
 import { useRouter } from 'vue-router'
-import { toast } from 'vue3-toastify'
 import RightClickMenu from '@/components/Core/RightClickMenu'
-import { useI18nUtils } from '@/composables'
+import { useClipboard, useI18nUtils } from '@/composables'
 import { downloadFile } from '@/helpers'
 import { useAppStore, useCategoryStore, useDashboardStore, useDialogStore, useMaindataStore, usePreferenceStore, useTagStore, useTorrentStore } from '@/stores'
 import { RightClickMenuEntryType, RightClickProperties } from '@/types/vuetorrent'
@@ -12,6 +11,7 @@ import { RightClickMenuEntryType, RightClickProperties } from '@/types/vuetorren
 const rightClickProperties = defineModel<RightClickProperties>({ required: true })
 
 const { t } = useI18nUtils()
+const { copyOrOpenDialog } = useClipboard()
 const router = useRouter()
 const appStore = useAppStore()
 const categoryStore = useCategoryStore()
@@ -157,25 +157,6 @@ async function toggleTag(tag: string) {
   if (hasTag(tag)) await torrentStore.removeTorrentTags(hashes.value, [tag])
   else await torrentStore.addTorrentTags(hashes.value, [tag])
   maindataStore.syncMaindata()
-}
-
-function copyValue(valueToCopy: string) {
-  function openLegacyCopyDialog() {
-    dialogStore.createDialog(
-      defineAsyncComponent(() => import('@/components/Dialogs/LegacyCopyDialog.vue')),
-      { value: valueToCopy }
-    )
-  }
-
-  if (!window.isSecureContext) {
-    openLegacyCopyDialog()
-    return
-  }
-
-  navigator.clipboard.writeText(valueToCopy).then(
-    () => toast.success(t('toast.copy.success')),
-    () => openLegacyCopyDialog()
-  )
 }
 
 function setDownloadLimit() {
@@ -401,24 +382,24 @@ const menuData = computed<RightClickMenuEntryType[]>(() => [
       {
         text: t('dashboard.right_click.copy.name'),
         icon: 'mdi-alphabetical-variant',
-        action: () => void copyValue(torrents.value.map(t => t.name).join('\n')),
+        action: () => void copyOrOpenDialog(torrents.value.map(t => t.name).join('\n')),
       },
       {
         text: t('dashboard.right_click.copy.hash'),
         icon: 'mdi-pound',
-        action: () => void copyValue(torrents.value.map(t => t.hash).join('\n')),
+        action: () => void copyOrOpenDialog(torrents.value.map(t => t.hash).join('\n')),
       },
       {
         text: t('dashboard.right_click.copy.magnet'),
         icon: 'mdi-magnet',
-        action: () => void copyValue(torrents.value.map(t => t.magnet).join('\n')),
+        action: () => void copyOrOpenDialog(torrents.value.map(t => t.magnet).join('\n')),
       },
       {
         text: t('dashboard.right_click.copy.comment'),
         icon: 'mdi-comment-text',
         hidden: !appStore.isFeatureAvailable('5.0.0'),
         disabled: !torrent.value?.comment,
-        action: () => void copyValue(torrents.value.map(t => t.comment).join('\n\n')),
+        action: () => void copyOrOpenDialog(torrents.value.map(t => t.comment).join('\n\n')),
       },
     ],
   },

--- a/src/components/Settings/ApiKeyGenerator.vue
+++ b/src/components/Settings/ApiKeyGenerator.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import { computed, defineAsyncComponent } from 'vue'
+import { computed } from 'vue'
 import { toast } from 'vue3-toastify'
-import { useI18nUtils } from '@/composables'
+import { useClipboard, useI18nUtils } from '@/composables'
 import qbit from '@/services/qbit'
-import { useDialogStore, usePreferenceStore } from '@/stores'
+import { usePreferenceStore } from '@/stores'
 
 const { t } = useI18nUtils()
-const dialogStore = useDialogStore()
+const { copyOrOpenDialog } = useClipboard()
 const preferenceStore = usePreferenceStore()
 
 const apiKey = computed(() => preferenceStore.preferences?.web_ui_api_key ?? '')
@@ -21,15 +21,7 @@ const maskedKey = computed(() => {
 
 async function copyKey() {
   if (!hasKey.value) return
-  try {
-    await navigator.clipboard.writeText(apiKey.value)
-    toast.success(t('toast.copy.success'))
-  } catch {
-    dialogStore.createDialog(
-      defineAsyncComponent(() => import('@/components/Dialogs/LegacyCopyDialog.vue')),
-      { value: apiKey.value }
-    )
-  }
+  await copyOrOpenDialog(apiKey.value)
 }
 
 async function regenerateKey() {

--- a/src/components/Settings/ApiKeyGenerator.vue
+++ b/src/components/Settings/ApiKeyGenerator.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, defineAsyncComponent } from 'vue'
 import { toast } from 'vue3-toastify'
 import { useI18nUtils } from '@/composables'
 import qbit from '@/services/qbit'
-import { usePreferenceStore } from '@/stores'
+import { useDialogStore, usePreferenceStore } from '@/stores'
 
 const { t } = useI18nUtils()
+const dialogStore = useDialogStore()
 const preferenceStore = usePreferenceStore()
 
 const apiKey = computed(() => preferenceStore.preferences?.web_ui_api_key ?? '')
@@ -24,7 +25,10 @@ async function copyKey() {
     await navigator.clipboard.writeText(apiKey.value)
     toast.success(t('toast.copy.success'))
   } catch {
-    toast.error(t('toast.copy.error'))
+    dialogStore.createDialog(
+      defineAsyncComponent(() => import('@/components/Dialogs/LegacyCopyDialog.vue')),
+      { value: apiKey.value }
+    )
   }
 }
 

--- a/src/composables/Clipboard.ts
+++ b/src/composables/Clipboard.ts
@@ -1,0 +1,34 @@
+import { defineAsyncComponent } from 'vue'
+import { toast } from 'vue3-toastify'
+import { useI18nUtils } from './i18n'
+import { useDialogStore } from '@/stores'
+
+export function useClipboard() {
+  const { t } = useI18nUtils()
+  const dialogStore = useDialogStore()
+
+  function openLegacyCopyDialog(value: string) {
+    dialogStore.createDialog(
+      defineAsyncComponent(() => import('@/components/Dialogs/LegacyCopyDialog.vue')),
+      { value }
+    )
+  }
+
+  async function copyOrOpenDialog(valueToCopy: string) {
+    if (!window.isSecureContext || !navigator.clipboard) {
+      openLegacyCopyDialog(valueToCopy)
+      return
+    }
+
+    try {
+      await navigator.clipboard.writeText(valueToCopy)
+      toast.success(t('toast.copy.success'))
+    } catch {
+      openLegacyCopyDialog(valueToCopy)
+    }
+  }
+
+  return {
+    copyOrOpenDialog,
+  }
+}

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -1,5 +1,6 @@
 import { useArrayPagination } from './ArrayPagination'
 import { useBackendSync } from './BackendSync'
+import { useClipboard } from './Clipboard'
 import { useDialog } from './Dialog'
 import { useI18nUtils } from './i18n'
 import { useSearchQuery } from './SearchQuery'
@@ -8,4 +9,4 @@ import { useTimer } from './Timer'
 import { useTorrentBuilder } from './TorrentBuilder'
 import { useTreeBuilder } from './TreeBuilder'
 
-export { useArrayPagination, useBackendSync, useDialog, useI18nUtils, useSearchQuery, useTableResize, useTimer, useTorrentBuilder, useTreeBuilder }
+export { useArrayPagination, useBackendSync, useClipboard, useDialog, useI18nUtils, useSearchQuery, useTableResize, useTimer, useTorrentBuilder, useTreeBuilder }


### PR DESCRIPTION
Fixes #2878

#2784 introduces this by requiring secure context "the old way".
A component were added in #2418 to allow for manual user copy instead.
