### PR TITLE
fix(search): guard against overlapping results polls desyncing the offset

### DIFF
--- a/src/pages/SearchEngine.vue
+++ b/src/pages/SearchEngine.vue
@@ -5,7 +5,7 @@ import { useRouter } from 'vue-router'
 import { useDisplay } from 'vuetify'
 import HistoryField from '@/components/Core/HistoryField.vue'
 import PluginManagerDialog from '@/components/Dialogs/PluginManagerDialog.vue'
-import { useI18nUtils, useSearchQuery } from '@/composables'
+import { useI18nUtils, useSearchQuery, useTimer } from '@/composables'
 import { HistoryKey } from '@/constants/vuetorrent'
 import { comparators, formatData, formatTimeSec, openLink } from '@/helpers'
 import { useAddTorrentStore, useAppStore, useDialogStore, useSearchEngineStore, useVueTorrentStore } from '@/stores'
@@ -93,17 +93,30 @@ function openResultLink(result: SearchResult) {
   openLink(result.descrLink)
 }
 
+// One timer for the page rather than one interval per tab: useTimer drops a run while the
+// previous one is still going, so a response slower than the interval can no longer be raced
+// by the next tick — which is what let two polls read the same offset and push the same
+// results twice, overshooting the server's count and 409-ing every poll after that.
+const { pause: pausePolling, resume: resumePolling } = useTimer(refreshActiveSearches, 1000, { immediate: false })
+
+async function refreshActiveSearches() {
+  const activeTabs = searchData.value.filter(tab => tab.id !== 0)
+  if (activeTabs.length === 0) {
+    pausePolling()
+    return
+  }
+
+  await Promise.allSettled(activeTabs.map(refreshResults))
+}
+
 async function runNewSearch() {
   await searchEngineStore.runNewSearch(selectedTab.value)
-  selectedTab.value.timer = setInterval(() => void refreshResults(selectedTab.value), 1000)
+  resumePolling()
   queryInput.value?.saveValueToHistory()
 }
 
 async function stopSearch(tab: SearchData) {
   await searchEngineStore.stopSearch(tab)
-  if (tab.timer) {
-    clearInterval(tab.timer)
-  }
 }
 
 function stopAllSearch() {
@@ -138,21 +151,16 @@ onBeforeMount(async () => {
   document.addEventListener('keydown', handleKeyboardShortcut)
   if (searchData.value.length === 0) {
     searchEngineStore.createNewTab()
-  } else {
-    searchData.value.forEach((tab: SearchData) => {
-      if (tab.id && tab.id !== 0) {
-        tab.timer = setInterval(() => void searchEngineStore.refreshResults(tab), 1000)
-      }
-    })
+  } else if (searchData.value.some((tab: SearchData) => tab.id !== 0)) {
+    // A tab restored from sessionStorage may still reference a live job. Resume so it keeps
+    // collecting results, and so it stops on its own once the job reports 'Stopped'.
+    resumePolling()
   }
   await searchEngineStore.fetchSearchPlugins()
 })
 
 onBeforeUnmount(() => {
   document.removeEventListener('keydown', handleKeyboardShortcut)
-  searchData.value.forEach((tab: SearchData) => {
-    if (tab.timer) clearInterval(tab.timer)
-  })
 })
 </script>
 

--- a/src/stores/searchEngine.spec.ts
+++ b/src/stores/searchEngine.spec.ts
@@ -1,0 +1,116 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { useSearchEngineStore } from './searchEngine'
+
+/**
+ * Simulated qBittorrent search backend.
+ *
+ * Mirrors searchcontroller.cpp: results accumulate while a job runs, and an
+ * offset past the current result count is rejected with 409 Conflict
+ * ("Offset is out of range").
+ */
+const server = {
+  total: 0,
+  latencyMs: 0,
+  /** Simulates a job qBittorrent no longer knows about (it keeps them in memory). */
+  jobMissing: false,
+}
+
+/** axios.isAxiosError() only checks this flag, so the store treats these as real API errors. */
+function apiError(message: string, status: number) {
+  return Object.assign(new Error(message), { isAxiosError: true, response: { status } })
+}
+
+vi.mock('@/services/qbit', () => ({
+  default: {
+    getSearchResults: vi.fn(async (_id: number, offset = 0) => {
+      // Offset is captured by the caller *before* this resolves — that window is the bug.
+      await new Promise(resolve => setTimeout(resolve, server.latencyMs))
+
+      if (server.jobMissing) {
+        throw apiError('Not Found', 404)
+      }
+
+      if (offset > server.total) {
+        throw apiError('Offset is out of range', 409)
+      }
+
+      const results = Array.from({ length: server.total - offset }, (_, i) => ({ fileName: `result-${offset + i}` }))
+      return { results, status: 'Running' as const, total: server.total }
+    }),
+    stopSearch: vi.fn(() => Promise.resolve()),
+    startSearch: vi.fn(() => Promise.resolve({ id: 1 })),
+    getSearchPlugins: vi.fn(() => Promise.resolve([])),
+  },
+}))
+
+function makeTab(store: ReturnType<typeof useSearchEngineStore>) {
+  store.$reset()
+  const tab = store.searchData[0]
+  tab.id = 1
+  tab.results = []
+  return tab
+}
+
+describe('stores/searchEngine', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    server.total = 0
+    server.latencyMs = 0
+    server.jobMissing = false
+  })
+
+  test('a response for a job that is no longer current is discarded', async () => {
+    const store = useSearchEngineStore()
+    const tab = makeTab(store)
+
+    server.total = 100
+    server.latencyMs = 20
+
+    const inFlight = store.refreshResults(tab)
+    // The user restarts the search while that request is still out: runNewSearch() swaps in
+    // the new job id and empties the results.
+    tab.id = 2
+    tab.results = []
+
+    // Appending the old job's 100 results here would put the new job's offset past its own
+    // result count — the same desync, reintroduced by a late response.
+    await expect(inFlight).resolves.toBe('Running')
+    expect(tab.results).toHaveLength(0)
+  })
+
+  test('an error for a job that is no longer current does not stop the new job', async () => {
+    const store = useSearchEngineStore()
+    const tab = makeTab(store)
+
+    server.total = 0
+    server.latencyMs = 20
+    tab.results = Array.from({ length: 50 }, (_, i) => ({ fileName: `stale-${i}` })) as typeof tab.results
+
+    const inFlight = store.refreshResults(tab)
+    tab.id = 2
+    tab.results = []
+
+    // Reporting 'Stopped' would make the caller tear down a search the user has just started.
+    await expect(inFlight).resolves.toBe('Running')
+  })
+
+  test('a desynced offset (409) reports the job as stopped instead of retrying forever', async () => {
+    const store = useSearchEngineStore()
+    const tab = makeTab(store)
+
+    server.total = 10
+    tab.results = Array.from({ length: 50 }, (_, i) => ({ fileName: `stale-${i}` })) as typeof tab.results
+
+    await expect(store.refreshResults(tab)).resolves.toBe('Stopped')
+  })
+
+  test('a missing search job (404) reports the job as stopped', async () => {
+    const store = useSearchEngineStore()
+    const tab = makeTab(store)
+
+    server.jobMissing = true
+
+    await expect(store.refreshResults(tab)).resolves.toBe('Stopped')
+  })
+})

--- a/src/stores/searchEngine.ts
+++ b/src/stores/searchEngine.ts
@@ -1,3 +1,4 @@
+import { isAxiosError } from 'axios'
 import { acceptHMRUpdate, defineStore } from 'pinia'
 import { v4 as uuidv4 } from 'uuid'
 import { ref } from 'vue'
@@ -24,7 +25,6 @@ export const useSearchEngineStore = defineStore(
           plugin: 'enabled',
         },
         results: [],
-        timer: null,
       })
     }
 
@@ -40,10 +40,33 @@ export const useSearchEngineStore = defineStore(
     }
 
     async function refreshResults(tab: SearchData) {
-      const response = await qbit.getSearchResults(tab.id, tab.results.length)
-      tab.results.push(...response.results)
+      // The job can be restarted or stopped while this request is in flight. Remember which
+      // job we asked about so a late response can't be applied to a different one.
+      const requestedId = tab.id
 
-      return response.status
+      try {
+        const response = await qbit.getSearchResults(requestedId, tab.results.length)
+        if (tab.id !== requestedId) {
+          // Stale: appending here would corrupt the new job's offset, and reporting a
+          // terminal status would stop a search the user has just started.
+          return 'Running' as const
+        }
+        tab.results.push(...response.results)
+
+        return response.status
+      } catch (error) {
+        if (tab.id !== requestedId) {
+          return 'Running' as const
+        }
+        // 404: the search job no longer exists (qBittorrent keeps them in memory, so a restart drops them).
+        // 409: our offset is beyond the job's result count, so every subsequent poll fails the same way.
+        // Neither can recover by retrying, so report the job as stopped and let the caller stop polling.
+        if (isAxiosError(error) && (error.response?.status === 404 || error.response?.status === 409)) {
+          return 'Stopped' as const
+        }
+
+        throw error
+      }
     }
 
     async function stopSearch(tab: SearchData) {

--- a/src/types/vuetorrent/SearchData.ts
+++ b/src/types/vuetorrent/SearchData.ts
@@ -9,7 +9,6 @@ interface SearchFilters {
 export interface SearchData {
   uniqueId: string
   id: number
-  timer: NodeJS.Timeout | null
   lastQuery: string
   query: string
   itemsPerPage: number


### PR DESCRIPTION
# Fix overlapping search polls desyncing the offset into a permanent 409 loop [fix]

Fixes #2883

> **Updated 2026-08-04** after @Larsluph's review: polling now goes through the existing `useTimer` composable instead of the hand-rolled guard this PR originally added, and it also fixes the stale-response race CodeRabbit spotted. The sections below describe the current diff.

## What this fixes

See #2883 for the full analysis. In short: `SearchEngine.vue` polls with `setInterval(..., 1000)` and `searchEngine.ts` uses `tab.results.length` as the request offset. There's no in-flight guard, so if a `/search/results` response takes longer than a second, two polls overlap: both read the same offset, both get the same window, and both push it. `results.length` overshoots the job's `total` and never recovers, so qBittorrent returns `409 Offset is out of range` on every subsequent poll — retried forever, because `refreshResults` has no `catch` and both callers use `() => void refreshResults(tab)`.

I measured **9158 x `409` at ~8 req/s over 28 minutes** from a single browser. Notably **8742 of those came from the WAN client and only 416 from the LAN**, plus 829 x `499` (client aborted) — consistent with the latency requirement. I could not reproduce it from a LAN client at all, which is probably why it hasn't surfaced before.

## Changes

**`src/pages/SearchEngine.vue`**
- Replace the per-tab `setInterval` handles with a single page-level `useTimer`. Its task is `.drop()`-ed, so a tick is skipped while the previous one is still in flight — that is the root-cause fix, and it uses the project's existing idiom rather than introducing a new one. It also pauses polling while the VueTorrent tab is hidden.
- One timer for the page rather than one per tab, since a composable can't be instantiated per tab in a loop. The timer refreshes every tab that has a live job and pauses itself when none are left.
- The `onBeforeMount` restore path previously called `searchEngineStore.refreshResults(tab)` directly, ignoring the returned `'Stopped'`, so a restored tab polled forever even after a clean completion. I observed a finished search still being polled 11 minutes later (at 1/min, clamped by background-tab throttling; 1/s in the foreground). It now goes through the same timer.

**`src/stores/searchEngine.ts`**
- Capture the job id before awaiting and discard a response that comes back for a different one. `.drop()` prevents two polls overlapping but not a single in-flight poll outliving the job it was issued for: stop or restart a search while a request is out, and the late response would either append the old job's results to the new job's freshly emptied array — recreating this exact desync — or report a terminal status and tear down the search just started.
- Treat `404` (job gone — qBittorrent keeps search jobs in memory) and `409` (offset past the result count) as terminal, returning `'Stopped'` so the caller stops polling. Other errors propagate unchanged. Narrowed with `axios.isAxiosError()`.

**`src/types/vuetorrent/SearchData.ts`**
- Remove the now-unused `timer` field. Flagging this as scope creep on my part — happy to leave it in place if you'd rather.

**`src/stores/searchEngine.spec.ts`** (new)
- Four tests: a stale success response is discarded, a stale error doesn't stop the new job, and `404` / `409` are terminal. All four fail against the unpatched store and pass against the patched one.
- This is the first spec under `src/stores/`, so I kept it to plain `vitest` + `createPinia()` with no new helpers or patterns.

## Testing

- New spec against the unpatched store: **4/4 fail**. With the fix: **4/4 pass**
- Full suite: **380 tests / 26 files** (376 on master + 4 here), all passing
- `npm run lint` — clean · `vue-tsc` — clean · `npm run build` — clean
- Running the patched build against qBittorrent **5.2.3** on my own server. A full search polled at exactly 1 req/s across 106 consecutive seconds, never 2, then stopped cleanly, with 0 x 409. *(That measurement is from the original implementation; the current one polls through `useTimer`, which is strictly more conservative.)*

## Behaviour changes worth flagging

- A search that hits `409`/`404` now **stops** rather than retrying forever. That's the intent, but the search ends quietly with no message to the user. A toast would arguably be better; I left it out to keep the diff small and to avoid inventing copy and a translation key uninvited. Happy to add it.
- Polling now pauses while the tab is hidden, inherited from `useTimer`. A background search collects results only once the tab is focused again.

## Limitations — what I did *not* verify

- The tests cover the store. Nothing covers the timer wiring itself, which would need the page mounted with router, i18n, Vuetify and several stores — happy to write that if you want it.
- I never reproduced the `409` storm in a browser — only in the unit test and in production logs. The real-world path needs a latency-bound client.
- Tested against qBittorrent 5.2.3. Per @Larsluph's suggestion I traced `searchcontroller.cpp` instead of testing older builds: the `404` / `409` paths this PR relies on are unchanged from `release-4.2.5` to current master (details in the comments below).

## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code

---

*The investigation and patch were done with AI assistance (Claude); I reviewed the diff, built and deployed it, and the measurements above are from my own instance.*