### PR TITLE
Various fixes

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { storeToRefs } from 'pinia'
-import { defineAsyncComponent, onBeforeMount, onMounted, watch, watchEffect, onBeforeUnmount } from 'vue'
+import { onBeforeMount, onMounted, watch, watchEffect, onBeforeUnmount } from 'vue'
 import { toast } from 'vue3-toastify'
 import AddPanel from './components/AddPanel.vue'
 import DnDZone from './components/DnDZone.vue'
@@ -85,9 +85,7 @@ function addLaunchQueueConsumer() {
   }
   win.launchQueue?.setConsumer(launchParams => {
     if (launchParams.files && launchParams.files.length) {
-      void Promise.all(launchParams.files.map(async file => addTorrentStore.pushTorrentToQueue(await file.getFile()))).then(() =>
-        dialogStore.createDialog(defineAsyncComponent(() => import('./components/Dialogs/AddTorrentDialog.vue')))
-      )
+      void Promise.all(launchParams.files.map(async file => addTorrentStore.pushTorrentToQueue(await file.getFile()))).then(dialogStore.initAndOpenAddTorrentDialog)
     }
   })
 }

--- a/src/components/AddPanel.vue
+++ b/src/components/AddPanel.vue
@@ -1,17 +1,16 @@
 <script setup lang="ts">
-import { defineAsyncComponent } from 'vue'
 import { useAddTorrentStore, useDialogStore } from '@/stores'
 
 const addTorrentStore = useAddTorrentStore()
 const dialogStore = useDialogStore()
-
-function openAddTorrentDialog() {
-  dialogStore.createDialog(defineAsyncComponent(() => import('./Dialogs/AddTorrentDialog.vue')))
-}
 </script>
 
 <template>
-  <v-bottom-navigation v-touch="{ up: openAddTorrentDialog }" :active="addTorrentStore.pendingTorrentsCount > 0" class="cursor-pointer" @click="openAddTorrentDialog">
+  <v-bottom-navigation
+    v-touch="{ up: dialogStore.initAndOpenAddTorrentDialog }"
+    :active="addTorrentStore.pendingTorrentsCount > 0"
+    class="cursor-pointer"
+    @click="dialogStore.initAndOpenAddTorrentDialog">
     <v-list-item :title="$t('navbar.addPanel.torrentsPendingCount', addTorrentStore.pendingTorrentsCount)" />
     <v-spacer />
     <v-list-item>

--- a/src/components/Dialogs/AddTorrentDialog.vue
+++ b/src/components/Dialogs/AddTorrentDialog.vue
@@ -98,7 +98,7 @@ function close() {
 }
 
 onBeforeMount(() => {
-  addTorrentStore.initForm()
+  addTorrentStore.tryInitForm()
 })
 </script>
 

--- a/src/components/DnDZone.vue
+++ b/src/components/DnDZone.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { useDropZone } from '@vueuse/core'
-import { defineAsyncComponent, onMounted, onUnmounted, ref } from 'vue'
+import { onMounted, onUnmounted, ref } from 'vue'
 import { useRoute } from 'vue-router'
 import { toast } from 'vue3-toastify'
 import { useI18nUtils } from '@/composables'
@@ -77,9 +77,7 @@ function onQueueDrop(files: File[] | null, event: DragEvent) {
   torrentFiles.forEach(addTorrentStore.pushTorrentToQueue)
   links.forEach(addTorrentStore.pushTorrentToQueue)
 
-  if (!dialogStore.hasActiveDialog) {
-    dialogStore.createDialog(defineAsyncComponent(() => import('./Dialogs/AddTorrentDialog.vue')))
-  }
+  dialogStore.initAndOpenAddTorrentDialog()
 }
 
 function onDownloadDrop(files: File[] | null, event: DragEvent) {
@@ -114,8 +112,8 @@ function onPaste(event: ClipboardEvent) {
   torrentFiles.forEach(addTorrentStore.pushTorrentToQueue)
   links.forEach(addTorrentStore.pushTorrentToQueue)
 
-  if ((torrentFiles.length || links.length) && !dialogStore.hasActiveDialog) {
-    dialogStore.createDialog(defineAsyncComponent(() => import('./Dialogs/AddTorrentDialog.vue')))
+  if (torrentFiles.length || links.length) {
+    dialogStore.initAndOpenAddTorrentDialog()
   }
 }
 

--- a/src/components/Navbar/SideWidgets/FilterSelectMulti.vue
+++ b/src/components/Navbar/SideWidgets/FilterSelectMulti.vue
@@ -108,10 +108,10 @@ function disableFilter(value: T) {
         <v-divider />
       </template>
       <template #selection="{ item, index }">
-        <span v-if="index === 0 && filterCount === 1" class="text-accent">
+        <span v-if="index === 0 && filterCount === 1" class="text-nowrap-hide text-accent">
           {{ item.title }}
         </span>
-        <span v-else-if="index === 0" class="text-accent">
+        <span v-else-if="index === 0" class="text-nowrap-hide text-accent">
           {{ t('navbar.side.filters.activeFilter', filterCount) }}
         </span>
       </template>
@@ -131,3 +131,11 @@ function disableFilter(value: T) {
     </v-autocomplete>
   </v-list-item>
 </template>
+
+<style lang="scss" scoped>
+.text-nowrap-hide {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+</style>

--- a/src/components/Navbar/SideWidgets/FilterSelectSingle.vue
+++ b/src/components/Navbar/SideWidgets/FilterSelectSingle.vue
@@ -47,9 +47,17 @@ const { t } = useI18nUtils()
         <v-divider />
       </template>
       <template #selection="{ item, index }">
-        <span v-if="index === 0 && modelValue.length === 1" class="text-accent">{{ item.title }}</span>
-        <span v-else-if="index === 0" class="text-accent">{{ t('navbar.side.filters.activeFilter', modelValue.length) }}</span>
+        <span v-if="index === 0 && modelValue.length === 1" class="text-nowrap-hide text-accent">{{ item.title }}</span>
+        <span v-else-if="index === 0" class="text-nowrap-hide text-accent">{{ t('navbar.side.filters.activeFilter', modelValue.length) }}</span>
       </template>
     </v-autocomplete>
   </v-list-item>
 </template>
+
+<style lang="scss" scoped>
+.text-nowrap-hide {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+</style>

--- a/src/components/Navbar/TopWidgets/TopContainer.vue
+++ b/src/components/Navbar/TopWidgets/TopContainer.vue
@@ -17,10 +17,6 @@ const torrentStore = useTorrentStore()
 const isOnTorrentDetail = computed(() => route.name === 'torrentDetail')
 const hashes = computed(() => (isOnTorrentDetail.value ? [route.params.hash as string] : dashboardStore.selectedTorrents))
 
-function openAddTorrentDialog() {
-  dialogStore.createDialog(defineAsyncComponent(() => import('@/components/Dialogs/AddTorrentDialog.vue')))
-}
-
 async function resumeTorrents() {
   if (!hashes.value.length) {
     dialogStore.confirmAction({
@@ -86,7 +82,7 @@ function openSettings() {
 <template>
   <v-tooltip :text="$t('topbar.addTorrents')" location="bottom">
     <template #activator="{ props }">
-      <v-btn icon="mdi-plus" v-bind="props" @click="openAddTorrentDialog" />
+      <v-btn icon="mdi-plus" v-bind="props" @click="dialogStore.initAndOpenAddTorrentDialog" />
     </template>
   </v-tooltip>
 

--- a/src/composables/SearchQuery.spec.ts
+++ b/src/composables/SearchQuery.spec.ts
@@ -99,4 +99,16 @@ describe('composables/SearchQuery', () => {
     const { results } = useSearchQuery(items, '"DAN DA DAN"', item => item)
     expect(results.value).toHaveLength(1)
   })
+
+  test('should not mutate the original array with empty query', () => {
+    const items = ['foo', 'bar', 'baz']
+    const { results } = useSearchQuery(
+      items,
+      '',
+      item => item,
+      items => items.sort()
+    )
+    expect(results.value).toEqual(['bar', 'baz', 'foo'])
+    expect(items).toEqual(['foo', 'bar', 'baz'])
+  })
 })

--- a/src/composables/SearchQuery.ts
+++ b/src/composables/SearchQuery.ts
@@ -15,14 +15,18 @@ export function useSearchQuery<T>(
 
     let res: T[]
 
-    if (query.startsWith('/') && query.endsWith('/')) {
-      const regex = new RegExp(query.substring(1, query.length - 2))
-      res = searchItems.filter(item => [getter(item)].flat().some(singleItem => regex.test(singleItem ?? '')))
+    if (query.trim()) {
+      if (query.startsWith('/') && query.endsWith('/')) {
+        const regex = new RegExp(query.substring(1, query.length - 2))
+        res = searchItems.filter(item => [getter(item)].flat().some(singleItem => regex.test(singleItem ?? '')))
+      } else {
+        const tokens = tokenize(query)
+        const inclusionTokens = tokens.filter(token => !token.startsWith('-'))
+        const exclusionTokens = tokens.filter(token => token.startsWith('-')).map(token => token.slice(1))
+        res = searchItems.filter(item => handleIncludeTokens(item, inclusionTokens) && handleExcludeTokens(item, exclusionTokens))
+      }
     } else {
-      const tokens = tokenize(query)
-      const inclusionTokens = tokens.filter(token => !token.startsWith('-'))
-      const exclusionTokens = tokens.filter(token => token.startsWith('-')).map(token => token.slice(1))
-      res = searchItems.filter(item => handleIncludeTokens(item, inclusionTokens) && handleExcludeTokens(item, exclusionTokens))
+      res = searchItems.slice()
     }
 
     return postProcess ? postProcess(res) : res

--- a/src/pages/MagnetHandler.vue
+++ b/src/pages/MagnetHandler.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { defineAsyncComponent, onBeforeMount } from 'vue'
+import { onBeforeMount } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useAddTorrentStore, useDialogStore } from '@/stores'
 
@@ -12,7 +12,7 @@ onBeforeMount(async () => {
   const magnetLink = decodeURIComponent(route.params.url as string)
   if (magnetLink.startsWith('magnet:')) {
     addTorrentStore.pushTorrentToQueue(magnetLink)
-    dialogStore.createDialog(defineAsyncComponent(() => import('@/components/Dialogs/AddTorrentDialog.vue')))
+    dialogStore.initAndOpenAddTorrentDialog()
   }
   await router.push({ name: 'dashboard' })
 })

--- a/src/stores/addTorrents.ts
+++ b/src/stores/addTorrents.ts
@@ -13,20 +13,17 @@ export const useAddTorrentStore = defineStore(
     const files = shallowRef<File[]>([])
     const urls = ref<string>('')
 
-    const form = reactive<
-      Partial<{
-        cookie: string
-        firstLastPiecePrio: boolean
-        rename: string
-        sequentialDownload: boolean
-      }>
-    >({})
+    const form = reactive({
+      cookie: undefined,
+      firstLastPiecePrio: false,
+      rename: undefined,
+      sequentialDownload: false,
+    })
     const addTorrentParams = reactive<AddTorrentParams>({})
 
     const pendingTorrentsCount = computed(() => files.value.length + urls.value.split('\n').filter(url => url.trim() !== '').length)
 
     function pushTorrentToQueue(torrentDescriptor: File | string) {
-      initForm()
       if (torrentDescriptor instanceof File) {
         files.value.push(torrentDescriptor)
       } else {
@@ -37,11 +34,14 @@ export const useAddTorrentStore = defineStore(
       }
     }
 
-    function initForm() {
-      if (isFirstInit.value) {
-        isFirstInit.value = false
-        resetForm()
+    function tryInitForm() {
+      if (!isFirstInit.value) {
+        return true
       }
+
+      const optionsLoaded = loadAddTorrentOptions()
+      isFirstInit.value = !optionsLoaded
+      return optionsLoaded
     }
 
     function resetForm() {
@@ -53,23 +53,33 @@ export const useAddTorrentStore = defineStore(
       form.rename = undefined
       form.sequentialDownload = false
 
-      addTorrentParams.add_to_top_of_queue = preferenceStore.preferences!.add_to_top_of_queue
+      return loadAddTorrentOptions()
+    }
+
+    function loadAddTorrentOptions() {
+      if (!preferenceStore.preferences) {
+        return false
+      }
+
+      addTorrentParams.add_to_top_of_queue = preferenceStore.preferences.add_to_top_of_queue
       addTorrentParams.category = undefined
-      addTorrentParams.content_layout = preferenceStore.preferences!.torrent_content_layout
+      addTorrentParams.content_layout = preferenceStore.preferences.torrent_content_layout
       addTorrentParams.download_limit = undefined
-      addTorrentParams.download_path = preferenceStore.preferences!.temp_path_enabled ? preferenceStore.preferences!.temp_path : undefined
+      addTorrentParams.download_path = preferenceStore.preferences.temp_path_enabled ? preferenceStore.preferences.temp_path : undefined
       addTorrentParams.forced = undefined
       addTorrentParams.inactive_seeding_time_limit = undefined
       addTorrentParams.ratio_limit = undefined
-      addTorrentParams.save_path = preferenceStore.preferences!.save_path
+      addTorrentParams.save_path = preferenceStore.preferences.save_path
       addTorrentParams.seeding_time_limit = undefined
       addTorrentParams.skip_checking = false
-      addTorrentParams.stop_condition = preferenceStore.preferences!.torrent_stop_condition
-      addTorrentParams.stopped = preferenceStore.preferences!.add_stopped_enabled ?? preferenceStore.preferences!.start_paused_enabled
+      addTorrentParams.stop_condition = preferenceStore.preferences.torrent_stop_condition
+      addTorrentParams.stopped = preferenceStore.preferences.add_stopped_enabled ?? preferenceStore.preferences.start_paused_enabled
       addTorrentParams.tags = undefined
       addTorrentParams.upload_limit = undefined
-      addTorrentParams.use_auto_tmm = preferenceStore.preferences!.auto_tmm_enabled
-      addTorrentParams.use_download_path = preferenceStore.preferences!.temp_path_enabled
+      addTorrentParams.use_auto_tmm = preferenceStore.preferences.auto_tmm_enabled
+      addTorrentParams.use_download_path = preferenceStore.preferences.temp_path_enabled
+
+      return true
     }
 
     return {
@@ -80,11 +90,10 @@ export const useAddTorrentStore = defineStore(
       addTorrentParams,
       pendingTorrentsCount,
       pushTorrentToQueue,
-      initForm,
+      tryInitForm,
       resetForm,
       $reset: () => {
-        isFirstInit.value = false
-        resetForm()
+        isFirstInit.value = !resetForm()
       },
     }
   },

--- a/src/stores/dialog.ts
+++ b/src/stores/dialog.ts
@@ -3,6 +3,7 @@ import { v4 as uuidv4 } from 'uuid'
 import { computed, defineAsyncComponent, shallowRef, triggerRef } from 'vue'
 import type { Component } from 'vue'
 import type { ComponentProps } from 'vue-component-type-helpers'
+import { useAddTorrentStore } from './addTorrents'
 import type ConfirmDialog from '@/components/Dialogs/Confirm/ConfirmDialog.vue'
 import type ConfirmListDialog from '@/components/Dialogs/Confirm/ConfirmListDialog.vue'
 
@@ -18,6 +19,8 @@ export const useDialogStore = defineStore('dialogs', () => {
   const dialogList = computed(() => Array.from(dialogs.value.values()))
 
   const hasActiveDialog = computed(() => dialogs.value.size > 0)
+
+  const addTorrentStore = useAddTorrentStore()
 
   function createDialog<C extends Component>(component: C, props?: Omit<ComponentProps<C>, 'guid'>, onClose?: () => void) {
     const guid = uuidv4()
@@ -55,6 +58,12 @@ export const useDialogStore = defineStore('dialogs', () => {
     )
   }
 
+  function initAndOpenAddTorrentDialog() {
+    if (hasActiveDialog.value || !addTorrentStore.tryInitForm()) return
+
+    createDialog(defineAsyncComponent(() => import('@/components/Dialogs/AddTorrentDialog.vue')))
+  }
+
   return {
     dialogList,
     hasActiveDialog,
@@ -62,6 +71,7 @@ export const useDialogStore = defineStore('dialogs', () => {
     deleteDialog,
     confirmAction,
     confirmListAction,
+    initAndOpenAddTorrentDialog,
     $reset: () => {
       dialogs.value.clear()
       triggerRef(dialogs)

--- a/src/stores/preferences.ts
+++ b/src/stores/preferences.ts
@@ -1,5 +1,6 @@
 import { acceptHMRUpdate, defineStore } from 'pinia'
 import { ref } from 'vue'
+import { useTask } from 'vue-concurrency'
 import qbit from '@/services/qbit'
 import AppPreferences from '@/types/qbit/models/AppPreferences'
 import { AppPreferencesPayload } from '@/types/qbit/payloads'
@@ -7,6 +8,10 @@ import { AppPreferencesPayload } from '@/types/qbit/payloads'
 export const usePreferenceStore = defineStore(
   'preferences',
   () => {
+    const task = useTask(function* () {
+      yield fetchPreferences()
+    }).drop()
+
     const preferences = ref<AppPreferences>()
 
     async function fetchPreferences() {
@@ -19,10 +24,10 @@ export const usePreferenceStore = defineStore(
 
     return {
       preferences,
-      fetchPreferences,
+      fetchPreferences: task.perform,
       setPreferences,
       $reset: async () => {
-        await fetchPreferences()
+        await task.perform()
       },
     }
   },


### PR DESCRIPTION
Following the report on #2762, I've imported fixes in the thread and from the fork while reworking them to be better integrated into the current architecture.

fix(MagnetHandler): Allow preloading magnets before login - Fixes #2762
perf: deduplicate concurrent preference requests on app init
fix(Filters): Prevent text wrap on navbar filters
perf(SearchQuery): Skip filtering on empty query

