### PR TITLE
fix: category form not fetching incomplete torrent path details

### DIFF
--- a/src/stores/categories.ts
+++ b/src/stores/categories.ts
@@ -10,7 +10,12 @@ export const useCategoryStore = defineStore('categories', () => {
   /** Key: Category name */
   const _categoryMap = shallowRef<Map<string, Category>>(new Map())
   const categories = useSorted(
-    () => Array.from(_categoryMap.value.values()),
+    () =>
+      Array.from(_categoryMap.value.values()).map(cat => ({
+        ...cat,
+        downloadPathEnabled: cat.download_path !== undefined && cat.download_path !== false,
+        downloadPath: cat.download_path !== undefined && typeof cat.download_path === 'string' ? cat.download_path : '',
+      })),
     (a, b) => comparators.text.asc(a.name, b.name)
   )
 

--- a/src/stores/categories.ts
+++ b/src/stores/categories.ts
@@ -10,12 +10,7 @@ export const useCategoryStore = defineStore('categories', () => {
   /** Key: Category name */
   const _categoryMap = shallowRef<Map<string, Category>>(new Map())
   const categories = useSorted(
-    () =>
-      Array.from(_categoryMap.value.values()).map(cat => ({
-        ...cat,
-        downloadPathEnabled: cat.download_path !== undefined && cat.download_path !== false,
-        downloadPath: cat.download_path !== undefined && typeof cat.download_path === 'string' ? cat.download_path : '',
-      })),
+    () => Array.from(_categoryMap.value.values()),
     (a, b) => comparators.text.asc(a.name, b.name)
   )
 
@@ -38,30 +33,23 @@ export const useCategoryStore = defineStore('categories', () => {
     return categories.value.filter(c => !usedCategories.includes(c.name)).map(c => c.name)
   })
 
+  function normalizeCategory(catName: string, qbitCat: Partial<Category>, oldCat?: Category): Category {
+    return {
+      name: qbitCat.name ?? oldCat?.name ?? catName,
+      savePath: qbitCat.savePath ?? oldCat?.savePath ?? '',
+      downloadPathEnabled: qbitCat.download_path !== undefined ? qbitCat.download_path !== false : (oldCat?.downloadPathEnabled ?? false),
+      downloadPath: qbitCat.download_path !== undefined ? (typeof qbitCat.download_path === 'string' ? qbitCat.download_path : '') : (oldCat?.downloadPath ?? ''),
+    }
+  }
+
   function syncFromMaindata(fullUpdate: boolean, entries: [string, Partial<Category>][], removed?: string[]) {
     if (fullUpdate) {
-      _categoryMap.value = new Map(entries as [string, Category][])
+      _categoryMap.value = new Map(entries.map(([catName, qbitCat]) => [catName, normalizeCategory(catName, qbitCat)]))
       return
     }
 
     for (const [catName, qbitCat] of entries) {
-      const oldCat = _categoryMap.value.get(catName)
-      if (oldCat) {
-        const newCat: Category = {
-          name: qbitCat.name ?? oldCat.name,
-          savePath: qbitCat.savePath ?? oldCat.savePath,
-          downloadPathEnabled: qbitCat.download_path !== undefined ? qbitCat.download_path !== false : oldCat.downloadPathEnabled,
-          downloadPath: qbitCat.download_path !== undefined ? (typeof qbitCat.download_path === 'string' ? qbitCat.download_path : '') : oldCat.downloadPath,
-        }
-        _categoryMap.value.set(catName, newCat)
-      } else {
-        _categoryMap.value.set(catName, {
-          name: qbitCat.name ?? catName,
-          savePath: qbitCat.savePath ?? '',
-          downloadPathEnabled: qbitCat.download_path !== undefined && qbitCat.download_path !== false,
-          downloadPath: typeof qbitCat.download_path === 'string' ? qbitCat.download_path : '',
-        })
-      }
+      _categoryMap.value.set(catName, normalizeCategory(catName, qbitCat, _categoryMap.value.get(catName)))
     }
     removed?.forEach(c => _categoryMap.value.delete(c))
     triggerRef(_categoryMap)


### PR DESCRIPTION
# category form not fetching incomplete torrent path details while form renders in edit mode [fix]

for Categories form in settings the incomplete download path is not populating correct as we are currently not transforming the data of downloadPathEnabled and downloadPath from download_path. where as for syncFromMetadata and other functions we are actually transforming the data to 2 keys.

This PR fixes this but correctly transforming data for Categories while loading them into store.

closes #2905

Proof of Testing:
https://github.com/user-attachments/assets/4f87118a-7658-40eb-b7cd-341070efd54d


## PR Checklist

- [x] I've started from master
- [x] I've only committed changes related to this PR
- [x] All tests pass
- [x] I've removed all commented code